### PR TITLE
Catching up with the AV code. Removing a call to basicConfig.

### DIFF
--- a/petastorm/hdfs/namenode.py
+++ b/petastorm/hdfs/namenode.py
@@ -23,7 +23,6 @@ import pyarrow
 from pyarrow.hdfs import HadoopFileSystem
 from pyarrow.lib import ArrowIOError
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Making this call overrides the logging in such a way that users of
this library cannot setup their own logging with `logging.basicConfig` if they
have previously imported this library (basicConfig will setup the logger only
if the log has not already been setup).  Remove this function call from atcpy
library. D107123