### PR TITLE
Decreasing the size of the dataset in test_end_to_end to speedup tests.

### DIFF
--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -49,7 +49,7 @@ def _randomize_row(id):
     row_dict = {
         TestSchema.id.name: id,
         TestSchema.id2.name: id % 2,
-        TestSchema.partition_key.name: 'p_{}'.format(int(id / 100)),
+        TestSchema.partition_key.name: 'p_{}'.format(int(id / 10)),
         TestSchema.python_primitive_uint8.name: np.random.randint(0, 255),
         TestSchema.image_png.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.uint8),
         TestSchema.matrix.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.float32),

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -40,7 +40,7 @@ from petastorm.workers_pool.thread_pool import ThreadPool
 
 # Number of rows in a fake dataset
 
-ROWS_COUNT = 1000
+ROWS_COUNT = 100
 
 SyntheticDataset = namedtuple('synthetic_dataset', ['url', 'data', 'path'])
 
@@ -136,13 +136,13 @@ def test_shuffle_drop_ratio(synthetic_dataset):
             ids = [row.id for row in reader]
         return ids
 
-    # Read ids twice without shuffle: assert we have the same array and all expected ids are in the array
+    # Read ids twice without shuffle: assert we have the same arra  y and all expected ids are in the array
     first_readout = readout_all_ids(False, 1)
     np.testing.assert_array_equal([r['id'] for r in synthetic_dataset.data], sorted(first_readout))
 
     # Test that the ids are increasingly not consecutive numbers as we increase the shuffle dropout
     prev_jumps_not_1 = 0
-    for shuffle_dropout in [2, 6, 11, 111]:
+    for shuffle_dropout in [2, 5, 8, 111]:
         readout = readout_all_ids(True, shuffle_dropout)
         assert len(first_readout) == len(readout)
         jumps_not_1 = np.sum(np.diff(readout) != 1)
@@ -328,20 +328,20 @@ def test_num_epochs_value_error(synthetic_dataset):
 
 def test_rowgroup_selector_integer_field(synthetic_dataset):
     """ Select row groups to read based on dataset index for integer field"""
-    with Reader(synthetic_dataset.url, rowgroup_selector=SingleIndexSelector(TestSchema.id.name, [2, 200]),
+    with Reader(synthetic_dataset.url, rowgroup_selector=SingleIndexSelector(TestSchema.id.name, [2, 18]),
                 reader_pool=DummyPool()) as reader:
         status = [False, False]
         count = 0
         for row in reader:
             if row.id == 2:
                 status[0] = True
-            if row.id == 200:
+            if row.id == 18:
                 status[1] = True
             count += 1
         # both id values in reader result
         assert all(status)
-        # read only 2 row groups, 100 rows per row group
-        assert 200 == count
+        # read only 2 row groups, 10 rows per row group
+        assert 20 == count
 
 
 def test_rowgroup_selector_string_field(synthetic_dataset):
@@ -354,7 +354,7 @@ def test_rowgroup_selector_string_field(synthetic_dataset):
             count += 1
         # Since we use artificial dataset all sensors have the same name,
         # so all row groups should be selected and all 1000 generated rows should be returned
-        assert 1000 == count
+        assert 100 == count
 
 
 def test_rowgroup_selector_wrong_index_name(synthetic_dataset):

--- a/petastorm/tests/test_sequence_end_to_end.py
+++ b/petastorm/tests/test_sequence_end_to_end.py
@@ -126,7 +126,7 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
                         sequence=sequence) as reader:
                 expected_id = 0
 
-                for _ in range(10):
+                for i in range(10 - length):
                     actual = next(reader)
                     expected_sequence = {}
                     for key in range(sequence.length):
@@ -221,7 +221,7 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
 
         with temporary_directory() as tmp_dir:
             tmp_url = 'file://{}'.format(tmp_dir)
-            ids = [0, 3, 8, 10, 11, 20, 30]
+            ids = [0, 3, 8, 10, 11, 20, 23]
             fields = set(TestSchema.fields.values()) - {TestSchema.matrix_nullable}
             dataset_dicts = create_test_dataset(tmp_url, ids, num_files=1)
             sequence = Sequence(length=2, delta_threshold=4, timestamp_field='id')
@@ -251,8 +251,8 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
                         self.assertIsNotNone(field.get_shape().dims)
                 second_item = sess.run(readout)
                 _assert_equal_sequence(second_item, {
-                    0: TestSchema.make_namedtuple(**dataset_dicts[2]),
-                    1: TestSchema.make_namedtuple(**dataset_dicts[3]),
+                    0: TestSchema.make_namedtuple(**dataset_dicts[3]),
+                    1: TestSchema.make_namedtuple(**dataset_dicts[4]),
                 }, skip_fields=['matrix_nullable'])
 
                 readout = tf_tensors(reader)
@@ -261,8 +261,8 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
                         self.assertIsNotNone(field.get_shape().dims)
                 third_item = sess.run(readout)
                 _assert_equal_sequence(third_item, {
-                    0: TestSchema.make_namedtuple(**dataset_dicts[3]),
-                    1: TestSchema.make_namedtuple(**dataset_dicts[4]),
+                    0: TestSchema.make_namedtuple(**dataset_dicts[5]),
+                    1: TestSchema.make_namedtuple(**dataset_dicts[6]),
                 }, skip_fields=['matrix_nullable'])
 
                 with self.assertRaises(OutOfRangeError):
@@ -278,7 +278,7 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
 
         with temporary_directory() as tmp_dir:
             tmp_url = 'file://{}'.format(tmp_dir)
-            ids = [0, 3, 8, 10, 11, 20, 30]
+            ids = [0, 3, 8, 10, 11, 20, 23]
             dataset_dicts = create_test_dataset(tmp_url, ids, 1)
             sequence = Sequence(length=2, delta_threshold=4, timestamp_field='id')
             with Reader(tmp_url, shuffle_options=ShuffleOptions(False),
@@ -294,14 +294,14 @@ class SequenceEndToEndDatasetToolkitTest(unittest.TestCase):
 
                 second_item = next(reader)
                 np.testing.assert_equal(second_item, {
-                    0: TestSchema.make_namedtuple(**dataset_dicts[2]),
-                    1: TestSchema.make_namedtuple(**dataset_dicts[3]),
+                    0: TestSchema.make_namedtuple(**dataset_dicts[3]),
+                    1: TestSchema.make_namedtuple(**dataset_dicts[4]),
                 })
 
                 third_item = next(reader)
                 np.testing.assert_equal(third_item, {
-                    0: TestSchema.make_namedtuple(**dataset_dicts[3]),
-                    1: TestSchema.make_namedtuple(**dataset_dicts[4]),
+                    0: TestSchema.make_namedtuple(**dataset_dicts[5]),
+                    1: TestSchema.make_namedtuple(**dataset_dicts[6]),
                 })
 
                 with self.assertRaises(StopIteration):


### PR DESCRIPTION
Made minor adjustments to test_sequence_end_to_end.py since rowgroup size has changed from 100 to 10.