### PR TITLE
Adding `six>=1.5.0` to a list of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ REQUIRED_PACKAGES = [
     'pandas>=0.19.0',
     'pyspark>=2.1.0',
     'pyzmq>=14.0.0',
-    'pyarrow>=0.10'
+    'pyarrow>=0.10',
+    'six>=1.5.0',
 ]
 
 if '--minimal-deps' not in sys.argv:


### PR DESCRIPTION
Tried 1.4.1 with the end to end test and it failed. Assuming 1.5.0 is the minimal version.