### PR TITLE
Add 'test' extra to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ else:
 EXTRA_REQUIRE = {
     'tf': ['tensorflow>=1.4.0'],
     'tf_gpu': ['tensorflow-gpu>=1.4.0'],
+    'test' : ['pytest>=3.0.0'],
 }
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
Allows to keep all dependencies in one place and keep track of pytest dependency.
Need to finetune the minimal version number of the dependency.