### PR TITLE
Fix channel ordering of encoded images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ python:
 install:
   # This will use requirements from setup.py and install them in the tavis's virtual environment
   # [tf] chooses to depend on cpu version of tensorflow (alternatively, could do [tf_gpu])
-  - pip install -e .[tf,pyarrow,opencv]
+  - pip install -e .[tf,pyarrow,opencv,test]
   # pyarrow was compiled against a newer version of numpy than we require so we need to upgrade it
   # (or optionally install pyarrow from source instead of through binaries)
   - pip install --upgrade numpy

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ else:
 EXTRA_REQUIRE = {
     'tf': ['tensorflow>=1.4.0'],
     'tf_gpu': ['tensorflow-gpu>=1.4.0'],
-    'test' : ['pytest>=3.0.0'],
+    'test' : ['pytest>=3.0.0', 'Pillow>=3.0'],
 }
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
We expect all inputs/outputs to the codec to be in RGB format. When we introduced opencv codec, we did not account for the fact that opencv expects all
its input/output images to be in BGR. This resulted in the serialized png streams become a non standard BGR streams. Also, it broke compatibility with older datasets that
wrote-out standard RGB PNG.

Fixing this issue by converting RGB impages into BGR before encoding. Reversing the BGR to RGB when decoding.