### PR TITLE
Try using travis-ci cache to speedup pip install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@
 
 dist: trusty
 language: python
+cache: pip
 python:
   - '2.7'
   - '3.6'
@@ -28,7 +29,7 @@ install:
 
 script:
   - pylint --rcfile=.pylintrc petastorm examples -f parseable -r n
-  - pytest
+  - pytest -v
 
 before_deploy:
   # Build a python wheel before deployment


### PR DESCRIPTION
I see ~70sec goes to pip install. Try the caching feature (caches $HOME/.cache/pip

Also make pytest output verbose to see if a test is "stuck"