### PR TITLE
[Part 2] New reader: ShufflingBuffer implementations (Random and Noop)

### DIFF
--- a/petastorm/reader_impl/epochs.py
+++ b/petastorm/reader_impl/epochs.py
@@ -1,0 +1,54 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+
+
+def epoch_generator(items, num_epochs, shuffle):
+    """This generator is used to generate epochs.
+
+    An epoch is a single pass on a set of data (without repetitions). If shuffle is False, items are yielded in
+    the same order as passed into the generator. If shuffle is True, the items order is reshuffled for each epoch.
+    If num_epochs is a None, infinite number of epochs will be generated. 'items' may contain any type of an
+    object/primitive.
+
+    Example:
+      assert list(epoch_generator([1, 2, 3], 1, False)) == [1, 2, 3]
+      assert list(epoch_generator([1, 2, 3], 2, False)) == [1, 2, 3, 1, 2, 3]
+
+    :param items: List of objects in a single epoch.
+    :param num_epochs: Number of epochs to generate
+    :param shuffle: If True, the order of items in each epoch is randomized
+    :return:
+    """
+    curr_item_index = 0
+
+    epochs_left = num_epochs
+
+    # Continue until 'epochs_left' is greater than 0. If 'None', continue forever
+    while (epochs_left is None or epochs_left > 0) and items:
+
+        if curr_item_index == 0 and shuffle:
+            random.shuffle(items)
+
+        yield items[curr_item_index]
+
+        curr_item_index += 1
+
+        if curr_item_index >= len(items):
+            curr_item_index = 0
+
+            # If iterations was set to None, that means we will iterate until stop is called
+            if epochs_left is not None:
+                epochs_left -= 1

--- a/petastorm/reader_impl/shuffling_buffer.py
+++ b/petastorm/reader_impl/shuffling_buffer.py
@@ -1,0 +1,180 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+
+import numpy as np
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ShufflingBufferBase(object):
+    """Shuffling implements a shuffling algorithm. Items can be added to the shuffling buffer and removed in a
+    different order as defined by the concrete shuffling algorithm. A shuffling buffer is intended to be used from
+    a single thread, hence, not thread safe."""
+    @abc.abstractmethod
+    def add_many(self, items):
+        """Adds multiple items to the buffer.
+
+        :param items: items to be added to the shuffling buffer.
+        :return: None
+        """
+        pass
+
+    @abc.abstractmethod
+    def retrieve(self):
+        """Selects an item from the buffer and returns the item to the caller. The item is removed from the buffer.
+
+        :return: The selected item.
+        """
+        pass
+
+    @abc.abstractmethod
+    def can_add(self):
+        """Checks the state of the buffer and returns whether a new item can be added to the buffer at the time.
+
+        :return: A boolean indicating whether an item can be added to the buffer at the time.
+        """
+        pass
+
+    @abc.abstractmethod
+    def can_retrieve(self):
+        """Checks the state of the buffer and returns whether an item can be removed from the buffer..
+
+        :return: A boolean indicating whether an item can be returned from the buffer at the time.
+        """
+        pass
+
+    @abc.abstractproperty
+    def size(self):
+        """Returns the number of elements currently present in the buffer.
+
+        :return: number of elements currently present in the buffer
+        """
+        pass
+
+    @abc.abstractmethod
+    def finish(self):
+        """Call this method when no more `add_many` calls will be made.
+
+        This allows a user to deplete the buffer. Typically during last epoch. Otherwise, we would always have leftovers
+        in the buffer at the end of the lifecycle.
+
+        :return: number of elements currently present in the buffer
+        """
+        pass
+
+class NoopShufflingBuffer(ShufflingBufferBase):
+    """A 'no-operation' (noop) implementation of a shuffling buffer. Useful in cases where no shuffling is desired, such
+    as test scenarios or iterating over a dataset in a predeterministic order.
+    """
+    def __init__(self):
+        self.store = []
+
+    def add_many(self, items):
+        self.store.extend(items)
+
+    def retrieve(self):
+        return self.store.pop(0)
+
+    def can_retrieve(self):
+        return len(self.store) > 0
+
+    def can_add(self):
+        return True
+
+    @property
+    def size(self):
+        return len(self.store)
+
+    def finish(self):
+        pass
+
+class RandomShufflingBuffer(ShufflingBufferBase):
+    """
+    A random shuffling buffer implementation. Items can be added to the buffer and retrieved in a random order.
+    """
+    def __init__(self, shuffling_buffer_capacity, min_after_retrieve, extra_capacity=1000):
+        """Initializes a new ShufflingBuffer instance.
+
+        Items may be retrieved from the buffer once `min_after_retrieve` items were added to the queue
+        (indicated by `can_retrieve`).
+
+        Items may be added to the buffer as long as the number of items in the buffer (not including the items
+        passed to `add_many`) does not exceed `shuffling_queue_capacity`.
+
+        The amount of items in the buffer may actually become more than `shuffling_buffer_capacity` since `add_many`
+        is passed a list of items. The 'hard limit' on the number of items in the buffer is
+        `shuffling_buffer_capacity` + `extra_queue_capacity`.
+
+        :param shuffling_buffer_capacity: Items may be added to the buffer as long as the amount of items in the
+        buffer does not exceed the value of `shuffling_queue_capacity` (not including the items
+        passed to `add_many`).
+        :param min_after_retrieve: Minimal amount of items in the buffer that allows retrieval. This is needed to
+        guarantee good random shuffling of elements. Once `finish()` is called, items can be retrieved even if the
+        condition does not hold.
+        :param extra_capacity: The amount of items in the buffer may grow above `shuffling_buffer_capacity`
+        (due to a call to `add_many` with a list of items), but must remain under `extra_queue_capacity`. Should be
+        set to the upper bound of the number of items that can be added in a single call to `add_many` (can be a
+        loose bound).
+        """
+        self._extra_capacity = extra_capacity
+        # Preallocate the shuffling buffer.
+        self._items = [None] * (shuffling_buffer_capacity + self._extra_capacity)
+        self._shuffling_queue_capacity = shuffling_buffer_capacity
+        self._min_after_dequeue = min_after_retrieve
+        self._size = 0
+        self._done_adding = False
+
+    def add_many(self, items):
+        if self._done_adding:
+            raise RuntimeError('Can not call add_many after done_adding() was called.')
+
+        if not self.can_add():
+            raise RuntimeError('Can not enqueue. Check the return value of "can_enqueue()" to check if more '
+                               'items can be added.')
+
+        # We leave self._extra_capacity slack to make sure we don't reallocate self._items array
+        expected_size = self._size + len(items)
+        maximal_capacity = self._shuffling_queue_capacity + self._extra_capacity
+        if expected_size > maximal_capacity:
+            raise RuntimeError('Attempt to enqueue more elements that the capacity allows. '
+                               'Current size: {}, new size {}, maximum allowed: {}'.format(self._size, expected_size,
+                                                                                           maximal_capacity))
+        self._items[self._size:self._size + len(items)] = items
+        self._size = expected_size
+
+    def retrieve(self):
+        if not self._done_adding and not self.can_retrieve():
+            raise RuntimeError('Can not dequeue. Check the return value of "can_dequeue()" to check if any '
+                               'items are available.')
+        random_index = np.random.randint(0, self._size)
+        return_value = self._items[random_index]
+        self._items[random_index] = self._items[self._size - 1]
+        self._items[self._size - 1] = None
+        self._size -= 1
+        return return_value
+
+    def can_add(self):
+        return self._size < self._shuffling_queue_capacity and not self._done_adding
+
+    def can_retrieve(self):
+        return self._size >= self._min_after_dequeue or (self._done_adding and self._size > 0)
+
+    @property
+    def size(self):
+        return self._size
+
+    def finish(self):
+        self._done_adding = True

--- a/petastorm/tests/test_epoch_generator.py
+++ b/petastorm/tests/test_epoch_generator.py
@@ -1,0 +1,44 @@
+from petastorm.reader_impl.epochs import epoch_generator
+
+
+def test_one_epoch():
+    assert list(epoch_generator([1, 2, 3], 1, False)) == [1, 2, 3]
+
+
+def test_three_epochs():
+    assert list(epoch_generator([1, 2, 3], 3, False)) == [1, 2, 3, 1, 2, 3, 1, 2, 3]
+
+
+def test_shuffle():
+    items_in_epoch = 50
+    shuffled_epoch = list(epoch_generator(list(range(items_in_epoch)), 1, True))
+    assert len(shuffled_epoch) == items_in_epoch
+    assert shuffled_epoch != range(items_in_epoch)
+
+
+def test_shuffle_per_epoch():
+    items_in_epoch = 50
+    two_epochs = list(epoch_generator(list(range(items_in_epoch)), 2, True))
+    assert len(two_epochs) == 100
+    assert two_epochs[:50] != two_epochs[50:]
+
+
+def test_empty_items_list():
+    assert not list(epoch_generator([], 2, True))
+    assert not list(epoch_generator([], None, True))
+
+
+def test_item_type_can_be_anything():
+    assert list(epoch_generator([None, 'a string', {}], 1, False)) == [None, 'a string', {}]
+
+
+def test_unlimited_epochs():
+    items = [1, 2, 3]
+    inf_epochs = epoch_generator(items, None, True)
+    for _ in range(1000):
+        actual_item = next(inf_epochs)
+        assert actual_item in items
+
+
+def test_one_item_epoch():
+    assert list(epoch_generator([1, ], 3, False)) == [1, 1, 1]

--- a/petastorm/tests/test_shuffling_buffer.py
+++ b/petastorm/tests/test_shuffling_buffer.py
@@ -1,0 +1,186 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import six
+
+from petastorm.reader_impl.shuffling_buffer import NoopShufflingBuffer, RandomShufflingBuffer
+
+
+def test_noop_shuffling_buffer():
+    """Noop should not do any shuffling. Add/retrieve some items while checking correcness of can_retrieve"""
+    q = NoopShufflingBuffer()
+
+    # Empty buffer. Can add, can not retrieve with zero size
+    assert q.size == 0
+    assert q.can_add()
+    assert not q.can_retrieve()
+
+    # Try adding some items. Check queue size and can_retrieve indicator
+    q.add_many([1])
+    assert q.can_add()
+    assert q.size == 1
+
+    q.add_many([2, 3])
+    assert q.size == 3
+
+    assert 1 == q.retrieve()
+    assert q.can_retrieve()
+
+    assert 2 == q.retrieve()
+    assert 3 == q.retrieve()
+    assert not q.can_retrieve()
+
+    # No effect is expected in noop implementation
+    q.finish()
+
+
+def test_random_shuffling_buffer_can_add_retrieve_flags():
+    """Check can_add/can_retrieve flags at all possible states"""
+    q = RandomShufflingBuffer(5, 3)
+
+    # Empty buffer. Can start adding, nothing to retrieve yet
+    assert q.size == 0
+    assert q.can_add()
+    assert not q.can_retrieve()
+
+    # Under min_after_retrieve elements, so can not retrieve just yet
+    q.add_many([1, 2])
+    assert q.can_add()
+    assert not q.can_retrieve()
+    assert q.size == 2
+
+    # Got to min_after_retrieve elements, can start retrieving
+    q.add_many([3])
+    assert q.can_retrieve()
+    assert q.size == 3
+
+    # But when we retrieve we are again under min_after_retrieve, so can not retrieve again
+    q.retrieve()
+    assert not q.can_retrieve()
+    assert q.size == 2
+
+    # Getting back to the retrievable state with enough items in the buffer
+    q.add_many([4, 5])
+    assert q.can_add()
+    assert q.can_retrieve()
+    assert q.size == 4
+
+    # Can overrun the capacity (as long as below extra_capacity), but can not add if we are above
+    # shuffling_buffer_capacity
+    q.add_many([6, 7, 8, 9])
+    assert not q.can_add()
+    with pytest.raises(RuntimeError):
+        q.add_many([1])
+    assert q.can_retrieve()
+    assert q.size == 8
+
+    # Getting one out. Still have more than shuffling_buffer_capacity
+    q.retrieve()
+    assert not q.can_add()
+    assert q.can_retrieve()
+    assert q.size == 7
+
+    # Retrieve enough to get back to addable state
+    [q.retrieve() for _ in range(4)]
+    assert q.can_add()
+    assert q.can_retrieve()
+    assert q.size == 3
+
+    # Retrieve the last element so we go under min_after_retrieve and can not retrieve any more
+    q.retrieve()
+    assert q.can_add()
+    assert not q.can_retrieve()
+    with pytest.raises(RuntimeError):
+        q.retrieve()
+
+    assert q.size == 2
+
+    # finish() will allow us to deplete the buffer completely
+    q.finish()
+    assert not q.can_add()
+    assert q.can_retrieve()
+    assert q.size == 2
+
+    q.retrieve()
+    assert not q.can_add()
+    assert q.can_retrieve()
+    assert q.size == 1
+
+    q.retrieve()
+    assert not q.can_add()
+    assert not q.can_retrieve()
+    assert q.size == 0
+
+
+def _feed_a_sequence_through_the_queue(shuffling_buffer, input_sequence):
+    assert shuffling_buffer.size == 0
+    assert not shuffling_buffer.can_retrieve()
+
+    retrieve_sequence = []
+    fro = 0
+    while True:
+        if shuffling_buffer.can_add():
+            to = min(fro + 3, len(input_sequence))
+            next_input_chunk = input_sequence[fro:to]
+            fro = to
+
+            shuffling_buffer.add_many(next_input_chunk)
+
+            if to >= len(input_sequence):
+                shuffling_buffer.finish()
+                break
+
+        for _ in range(2):
+            if shuffling_buffer.can_retrieve():
+                retrieve_sequence.append(shuffling_buffer.retrieve())
+
+    while shuffling_buffer.can_retrieve():
+        retrieve_sequence.append(shuffling_buffer.retrieve())
+
+    return retrieve_sequence
+
+
+def test_random_shuffling_buffer_stream_through():
+    """Feed a 0:99 sequence through a RandomShufflingBuffer. Check that the order has changed."""
+    input_sequence = range(100)
+    a = _feed_a_sequence_through_the_queue(RandomShufflingBuffer(10, 3), input_sequence)
+    b = _feed_a_sequence_through_the_queue(RandomShufflingBuffer(10, 3), input_sequence)
+    assert len(a) == len(input_sequence)
+    assert set(a) == set(b)
+    assert a != b
+
+
+def test_noop_shuffling_buffer_stream_through():
+    """Feed a 0:99 sequence through a NoopShufflingBuffer. Check that the order has not changed."""
+    expected = list(range(100))
+    actual = _feed_a_sequence_through_the_queue(NoopShufflingBuffer(), expected)
+    assert expected == actual
+
+
+def test_longer_random_sequence_of_queue_ops():
+    """A long random sequence of added and retrieved values"""
+    q = RandomShufflingBuffer(100, 80)
+
+    for _ in six.moves.xrange(10000):
+        if q.can_add():
+            q.add_many(np.random.random((np.random.randint(1, 10),)))
+        assert q.size < 100 + 10
+        for _ in range(np.random.randint(1, 10)):
+            if not q.can_retrieve():
+                break
+            # Make sure never get to less than `min_after_retrieve` elements
+            assert 80 <= q.size
+            q.retrieve()


### PR DESCRIPTION
Items can be added to a shuffling buffer and removed in a different order as defined by the concrete shuffling algorithm.

Currently we have a `NoopShufflingBuffer` implementation which is not really shuffling, but just a FIFO implementation. Used for tests and when we don't want to shuffle.

`RandomShufflingBuffer` implements a random shuffling buffer with low and high water marks.

Shuffling buffers are not intended to be thread safe.