### PR TITLE
Validate that dataset_url is string

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -15,6 +15,7 @@
 import collections
 import logging
 import os
+import six
 import warnings
 
 from pyarrow import parquet as pq
@@ -101,6 +102,9 @@ class Reader(object):
         #    c. partition: used to get a subset of data for distributed training
         # 4. Create a rowgroup ventilator object
         # 5. Start workers pool
+        if dataset_url is None or not isinstance(dataset_url, six.string_types):
+            raise ValueError("""dataset_url must be a string""")
+
         if not (isinstance(schema_fields, collections.Iterable) or isinstance(schema_fields, NGram)
                 or schema_fields is None):
             raise ValueError("""Fields must be either None, an iterable collection of Unischema fields or an NGram

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from petastorm.reader import Reader
+
+
+def test_dataset_url_must_be_string():
+    with pytest.raises(ValueError):
+        Reader(dataset_url=None)
+
+    with pytest.raises(ValueError):
+        Reader(dataset_url=123)
+
+    with pytest.raises(ValueError):
+        Reader(dataset_url=[])


### PR DESCRIPTION
Since we moved the order of arguments this validation is important to fail fast and prevent weird errors