### PR TITLE
Support passing unicode string as a dataset url.

### DIFF
--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pyarrow
+import six
 from six.moves.urllib.parse import urlparse
 
 from petastorm.hdfs.namenode import HdfsNamenodeResolver, HdfsConnector
@@ -46,7 +47,7 @@ class FilesystemResolver(object):
         # Cache the instantiated filesystem object
         self._filesystem = None
 
-        if isinstance(self._dataset_url, str):
+        if isinstance(self._dataset_url, six.string_types):
             self._parsed_dataset_url = urlparse(self._dataset_url)
         else:
             self._parsed_dataset_url = self._dataset_url

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -387,3 +387,11 @@ def test_materialize_dataset_hadoop_config(synthetic_dataset):
     assert hadoop_config.get('parquet.block.size.row.check.min') is None
     spark.sparkContext.stop()
     rmtree(destination)
+
+
+def test_dataset_path_is_a_unicode(synthetic_dataset):
+    """Just a bunch of read and compares of all values to the expected values using the different reader pools"""
+    # Making sure unicode_in_p23 is a unicode both in python 2 and 3
+    unicode_in_p23 = synthetic_dataset.url.encode().decode('utf-8')
+    with Reader(unicode_in_p23, reader_pool=DummyPool()) as reader:
+        next(reader)


### PR DESCRIPTION
Saw a failure on someone's machine. Was using 
```python 
from __future__ import unicode_literals
```