### PR TITLE
Make `petastorm_generate_metadata.py` lunchable when not installed as an entry_point.

### DIFF
--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -15,9 +15,9 @@
 """Script to add petastorm metadata to an existing parquet dataset"""
 
 import argparse
+import sys
 from pydoc import locate
 
-import sys
 from pyarrow import parquet as pq
 from pyspark.sql import SparkSession
 
@@ -108,4 +108,8 @@ def _main(args):
 
 
 def main():
+    _main(sys.argv[1:])
+
+
+if __name__ == '__main__':
     _main(sys.argv[1:])


### PR DESCRIPTION
Makes it easier to run, when the package is not properly installed.