### PR TITLE
Add option for driver memory in regenerating metadata

### DIFF
--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -106,12 +106,15 @@ def _main(args):
     parser.add_argument('--master', type=str,
                         help='Spark master. Default if not specified. To run on a local machine, specify '
                              '"local[W]" (where W is the number of local spark workers, e.g. local[10])')
+    parser.add_argument('--spark-driver-memory', type=str, help='The amount of memory the driver process will have',
+                        default='4g')
     args = parser.parse_args(args)
 
     # Open Spark Session
     spark_session = SparkSession \
         .builder \
-        .appName("Petastorm Metadata Index")
+        .appName("Petastorm Metadata Index") \
+        .config('spark.driver.memory', args.spark_driver_memory)
     if args.master:
         spark_session.master(args.master)
 


### PR DESCRIPTION
This was one of the issues in regenerating metadata (default memory is not enough)

The other is a permission issue, which is a bit trickier to solve but im working on a solution  HADOOP_USER_NAME doesnt work well because libhdfs3 does not respect it so if you have a dataset owned by `hdfs` and you need to regenerate the metadata you can tell spark to generate the summary files owned by `hdfs` but then when we try to add the unischema it will fail since the default files are not writeable by your username. I can elaborate more if necessary.