### PR TITLE
-Y switch and no-namedtuples-in-reader

### DIFF
--- a/petastorm/ngram.py
+++ b/petastorm/ngram.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import numbers
 
 from petastorm.unischema import UnischemaField
+
 
 class NGram(object):
     """
@@ -167,8 +167,7 @@ class NGram(object):
         """
         # Verify that each element and it's previous element do not exceed the delta_threshold
         for previous, current in zip(ngram[:-1], ngram[1:]):
-            if getattr(current, self._timestamp_field.name) - getattr(previous, self._timestamp_field.name) > \
-                    self.delta_threshold:
+            if current[self._timestamp_field.name] - previous[self._timestamp_field.name] > self.delta_threshold:
                 return False
         return True
 
@@ -208,8 +207,8 @@ class NGram(object):
             # Potential ngram: [index, index + self.length[
             potential_ngram = data[index:index + self.length]
 
-            is_sorted = all(getattr(potential_ngram[i], self._timestamp_field.name) <=
-                            getattr(potential_ngram[i + 1], self._timestamp_field.name)
+            is_sorted = all(potential_ngram[i][self._timestamp_field.name] <=
+                            potential_ngram[i + 1][self._timestamp_field.name]
                             for i in range(len(potential_ngram) - 1))
             if not is_sorted:
                 raise NotImplementedError('NGram assumes that the data is sorted by {0} field which is not the case'
@@ -218,7 +217,7 @@ class NGram(object):
             if not self.timestamp_overlap and prev_ngram_end_timestamp is not None:
                 # If we dont want timestamps of NGrams to overlap, check that the start timestamp of the next NGram
                 # is not less than the end timestamp of the previous NGram
-                next_ngram_start_timestamp = getattr(potential_ngram[0], self._timestamp_field.name)
+                next_ngram_start_timestamp = potential_ngram[0][self._timestamp_field.name]
                 if next_ngram_start_timestamp <= prev_ngram_end_timestamp:
                     continue
 
@@ -228,15 +227,38 @@ class NGram(object):
             if len(potential_ngram) == self.length and self._ngram_pass_threshold(potential_ngram):
                 new_item = {(base_key + key): value for (key, value) in enumerate(potential_ngram)}
                 for key in new_item:
-                    current_schema = self.get_schema_at_timestep(schema=schema, timestep=key)
                     # Get the data for that current timestep and create a namedtuple
-                    current_item = new_item[key]._asdict()
-                    new_item[key] = current_schema.make_namedtuple(
-                        **{k: current_item[k] for k in current_item if k in self.get_field_names_at_timestep(key)}
-                    )
+                    current_item = new_item[key]
+                    new_item[key] = {k: current_item[k]
+                                     for k in current_item if k in self.get_field_names_at_timestep(key)}
                 result.append(new_item)
 
                 if not self.timestamp_overlap:
-                    prev_ngram_end_timestamp = getattr(potential_ngram[-1], self._timestamp_field.name)
+                    prev_ngram_end_timestamp = potential_ngram[-1][self._timestamp_field.name]
 
         return result
+
+    def make_namedtuple(self, schema, ngram_as_dicts):
+        """Converts a ngram structure where mapped values are dictionaries to a mapped structure where mapped values
+        are namedtuples.
+
+        Example:
+          { -1 : {'f1': 10, 'f2': 20},
+             0 : {'f1': 30},
+          }
+
+        is converted to
+          { -1 : namedtuple(f1=10, f2=20),
+             0 : namedtuple(f1=30),
+          }
+
+        :param schema: schema used for conversion
+        :param ngram_as_dicts: ngram in the timestamp-to-dict mapping
+        :return: ngram in the timestamp-to-namedtuple mapping
+        """
+        ngram_as_tuples = {}
+        for timestamp in ngram_as_dicts.keys():
+            data_as_dict = ngram_as_dicts[timestamp]
+            current_schema = self.get_schema_at_timestep(schema=schema, timestep=timestamp)
+            ngram_as_tuples[timestamp] = current_schema.make_namedtuple(**data_as_dict)
+        return ngram_as_tuples

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -310,7 +310,12 @@ class Reader(object):
 
     def __next__(self):
         try:
-            return self._workers_pool.get_results(timeout=self._read_timeout_s)
+            # Namedtuples are returned to the user. All internal processing is done as dictionaries. Convert.
+            result = self._workers_pool.get_results(timeout=self._read_timeout_s)
+            if self.ngram:
+                return self.ngram.make_namedtuple(self.schema, result)
+            else:
+                return self.schema.make_namedtuple(**result)
         except EmptyResultError:
             raise StopIteration
 

--- a/petastorm/reader_worker.py
+++ b/petastorm/reader_worker.py
@@ -103,12 +103,10 @@ class ReaderWorker(WorkerBase):
             all_cols = self._local_cache.get(cache_key,
                                              lambda: self._load_rows(parquet_file, piece, shuffle_row_drop_partition))
 
-        all_cols_as_tuples = [self._schema.make_namedtuple(**row) for row in all_cols]
-
         if self._ngram:
-            all_cols_as_tuples = self._ngram.form_ngram(data=all_cols_as_tuples, schema=self._schema)
+            all_cols = self._ngram.form_ngram(data=all_cols, schema=self._schema)
 
-        for item in all_cols_as_tuples:
+        for item in all_cols:
             self.publish_func(item)
 
     def _load_rows(self, pq_file, piece, shuffle_row_drop_range):

--- a/petastorm/tests/conftest.py
+++ b/petastorm/tests/conftest.py
@@ -28,6 +28,7 @@ SyntheticDataset = namedtuple('synthetic_dataset', ['url', 'data', 'path'])
 
 ROWS_COUNT = 100
 
+_CACHE_FAKE_DATASET_OPTION_SHORT = '-Y'
 _CACHE_FAKE_DATASET_OPTION = '--cache-synthetic-dataset'
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 def pytest_addoption(parser):
     parser.addoption(
-        _CACHE_FAKE_DATASET_OPTION, action="store_true", default=False,
+        _CACHE_FAKE_DATASET_OPTION_SHORT, _CACHE_FAKE_DATASET_OPTION, action="store_true", default=False,
         help='Use a cached version of synthetic dataset if available. This helps speedup local tests reruns as '
              'we don\'t have to rerun spark. CAUTION: you won\'t be exercising dataset generating parts of petastorm '
              'hence tests results maybe inaccurate'


### PR DESCRIPTION
Two commits in this PR:
* Adding `-Y` shortcut for `--cache-synthetic-dataset`
* Obsoleting namedtuples within the reader internals implementations. Conversion to namedtuple happens right before values are returned to the user. (Resolves https://github.com/uber/petastorm/issues/91)