### PR TITLE
Add .py extension to metadata generation script

### DIFF
--- a/doc/migrating-0.3.0.md
+++ b/doc/migrating-0.3.0.md
@@ -78,14 +78,14 @@ with materialize_dataset(spark, dataset_url, MySchema):
 
 ## Updating Metadata Of Existing Datasets
 We changed how dataset metadata is stored, which will likely result in a warning message of:
-`You are using a deprecated metadata version. Please run petastorm-generate-metadata on spark to update.`
+`You are using a deprecated metadata version. Please run petastorm-generate-metadata.py on spark to update.`
 
 This is just recommending you to regenerate the metadata for any existing petastorm datasets to use the new structure.
 Luckily while in the past it took several minutes to regenerate metadata for a dataset, it now should only take a few
-seconds. There is a script `petastorm-generate-metadata` included in petastorm 0.3.0 which makes this easy.
+seconds. There is a script `petastorm-generate-metadata.py` included in petastorm 0.3.0 which makes this easy.
 Simply run:
 ```bash
-petastorm-generate-metadata --dataset_url hdfs://namenode-host:port/path/to/dataset
+petastorm-generate-metadata.py --dataset_url hdfs://namenode-host:port/path/to/dataset
 ```
 Which will regenerate the dataset metadata, reusing the schema information already there. By default this
 will run on your local pyspark which should be fine given that the job does not utilize any executors
@@ -98,7 +98,7 @@ a location in remote storage (e.g. HDFS) you will need write permission to both 
 `_common_metadata`/`_metadata` files (if they exist). The easiest way to accomplish this is to make the directory writeable
 to your user either by changing file permissions, changing file ownership, etc. The easiest way to guarantee success would
 be to `chmod -R` the directory to `777` however do this at your own risk. Another option would be to run
-`petastorm-generate-metadata` from within spark to have it share the same runtime environment permissions as the
+`petastorm-generate-metadata.py` from within spark to have it share the same runtime environment permissions as the
 original dataset run.
 
 

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -80,7 +80,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None):
     _generate_unischema_metadata(dataset, schema)
     if not dataset.metadata_path:
         raise MetadataGenerationError('Could not find summary metadata file. The dataset will exist but you will need'
-                                      ' to execute petastorm-generate-metadata before you can read your dataset '
+                                      ' to execute petastorm-generate-metadata.py before you can read your dataset '
                                       ' in order to generate the necessary metadata.'
                                       ' Try increasing spark driver memory next time and making sure you are'
                                       ' using parquet-mr >= 1.8.3')
@@ -159,7 +159,7 @@ def load_row_groups(dataset):
         raise ValueError('Could not find _metadata file.'
                          ' Use materialize_dataset(..) in petastorm.etl.dataset_metadata.py to generate'
                          ' this file in your ETL code.'
-                         ' You can generate it on an existing dataset using petastorm-generate-metadata')
+                         ' You can generate it on an existing dataset using petastorm-generate-metadata.py')
 
     num_row_groups = metadata.num_row_groups
 
@@ -168,14 +168,14 @@ def load_row_groups(dataset):
         return _split_row_groups(dataset)
 
     # If we don't have row groups in the common metadata we look for the old way of loading it
-    logger.warning('You are using a deprecated metadata version. Please run petastorm-generate-metadata'
+    logger.warning('You are using a deprecated metadata version. Please run petastorm-generate-metadata.py'
                    ' on spark to update.')
     dataset_metadata_dict = dataset.common_metadata.metadata
     if ROW_GROUPS_PER_FILE_KEY not in dataset_metadata_dict:
         raise ValueError('Could not find row group metadata in _metadata file.'
                          ' Use materialize_dataset(..) in petastorm.etl.dataset_metadata.py to generate'
                          ' this file in your ETL code.'
-                         ' You can generate it on an existing dataset using petastorm-generate-metadata')
+                         ' You can generate it on an existing dataset using petastorm-generate-metadata.py')
     metadata_dict_key = ROW_GROUPS_PER_FILE_KEY
     row_groups_per_file = json.loads(dataset_metadata_dict[metadata_dict_key].decode())
 
@@ -242,7 +242,7 @@ def get_schema(dataset):
         raise ValueError('Could not find _common_metadata file. Use materialize_dataset(..) in'
                          ' petastorm.etl.dataset_metadata.py to generate this file in your '
                          ' ETL code.'
-                         ' You can generate it on an existing dataset using petastorm-generate-metadata')
+                         ' You can generate it on an existing dataset using petastorm-generate-metadata.py')
 
     dataset_metadata_dict = dataset.common_metadata.metadata
 
@@ -254,7 +254,7 @@ def get_schema(dataset):
                          ' Make sure to use materialize_dataset(..) in'
                          ' petastorm.etl.dataset_metadata to'
                          ' properly generate this file in your ETL code.'
-                         ' You can generate it on an existing dataset using petastorm-generate-metadata')
+                         ' You can generate it on an existing dataset using petastorm-generate-metadata.py')
     ser_schema = dataset_metadata_dict[UNISCHEMA_KEY]
     # Since we have moved the unischema class around few times, unpickling old schemas will not work. In this case we
     # override the old import path to get backwards compatibility

--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -26,18 +26,20 @@ from petastorm.etl.rowgroup_indexing import ROWGROUPS_INDEX_KEY
 from petastorm.fs_utils import FilesystemResolver
 from petastorm.utils import add_to_dataset_metadata
 
-example_text = '''This is meant to be run as a spark job. Example (some replacement required):
+example_text = '''Example (some replacement required):
 
-On Spark:    spark-submit \
-    --master spark://ip:port \
-    $(which petastorm-generate-metadata) \
-    --dataset_url hdfs:///path/to/my/hello_world_dataset \
-    --unischema_class examples.hello_world.hello_world_dataset.HelloWorldSchema
-
-Locally:     petastorm-generate-metadata \
-    --dataset_url hdfs:///path/to/my/hello_world_dataset \
-    --unischema_class examples.hello_world.hello_world_dataset.HelloWorldSchema
+Locally:     
+petastorm-generate-metadata.py \\
+    --dataset_url hdfs:///path/to/my/hello_world_dataset \\
+    --unischema_class examples.hello_world.hello_world_dataset.HelloWorldSchema \\
     --master local[*]
+
+On Spark:    
+spark-submit \\
+    --master spark://ip:port \\
+    $(which petastorm-generate-metadata.py) \\
+    --dataset_url hdfs:///path/to/my/hello_world_dataset \\
+    --unischema_class examples.hello_world.hello_world_dataset.HelloWorldSchema
 '''
 
 
@@ -113,7 +115,7 @@ def _main(args):
     # Open Spark Session
     spark_session = SparkSession \
         .builder \
-        .appName("Petastorm Metadata Index") \
+        .appName("Petastorm Generate Metadata") \
         .config('spark.driver.memory', args.spark_driver_memory)
     if args.master:
         spark_session.master(args.master)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     license='Apache 2.0',
     extras_require=EXTRA_REQUIRE,
     entry_points = {
-        'console_scripts': ['petastorm-generate-metadata=petastorm.etl.petastorm_generate_metadata:main'],
+        'console_scripts': ['petastorm-generate-metadata.py=petastorm.etl.petastorm_generate_metadata:main'],
     },
 )


### PR DESCRIPTION
The reason for this is because to submit this as a spark job it must have a `.py` extension to run properly. Submitting as a spark job makes dealing with the permission issues easier.