### PR TITLE
Make `ROWS_COUNT` private to conftest.py

### DIFF
--- a/petastorm/tests/conftest.py
+++ b/petastorm/tests/conftest.py
@@ -25,7 +25,7 @@ from petastorm.tests.test_common import create_test_dataset
 SyntheticDataset = namedtuple('synthetic_dataset', ['url', 'data', 'path'])
 
 # Number of rows in a fake dataset
-ROWS_COUNT = 100
+_ROWS_COUNT = 100
 
 _CACHE_FAKE_DATASET_OPTION_SHORT = '-Y'
 _CACHE_FAKE_DATASET_OPTION = '--cache-synthetic-dataset'
@@ -76,7 +76,7 @@ def synthetic_dataset(request, tmpdir_factory):
     def _synthetic_dataset_no_cache():
         path = tmpdir_factory.mktemp("data").strpath
         url = 'file://' + path
-        data = create_test_dataset(url, range(ROWS_COUNT))
+        data = create_test_dataset(url, range(_ROWS_COUNT))
         dataset = SyntheticDataset(url=url, path=path, data=data)
         return dataset
 

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -23,7 +23,6 @@ from petastorm.codecs import ScalarCodec
 from petastorm.local_disk_cache import LocalDiskCache
 from petastorm.reader import Reader, ShuffleOptions
 from petastorm.selectors import SingleIndexSelector
-from petastorm.tests.conftest import ROWS_COUNT
 from petastorm.tests.test_common import create_test_dataset, TestSchema
 from petastorm.tests.test_end_to_end_predicates_impl import \
     PartitionKeyInSetPredicate, EqualPredicate
@@ -400,5 +399,5 @@ def test_dataset_path_is_a_unicode(synthetic_dataset):
 def test_reader_len(synthetic_dataset):
     with Reader(synthetic_dataset.url, reader_pool=DummyPool()) as reader:
         # multiple access yields the same value
-        assert len(reader) == ROWS_COUNT
-        assert len(reader) == ROWS_COUNT
+        assert len(reader) == len(synthetic_dataset.data)
+        assert len(reader) == len(synthetic_dataset.data)

--- a/petastorm/tests/test_pytorch_utils.py
+++ b/petastorm/tests/test_pytorch_utils.py
@@ -15,7 +15,6 @@ from __future__ import division
 
 from petastorm.pytorch import DataLoader
 from petastorm.reader import Reader
-from petastorm.tests.conftest import ROWS_COUNT
 from petastorm.workers_pool.dummy_pool import DummyPool
 
 
@@ -25,7 +24,7 @@ def _noop_collate(alist):
 
 def test_basic_pytorch_dataloader(synthetic_dataset):
     loader = DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()), collate_fn=_noop_collate)
-    assert len(loader) == ROWS_COUNT
+    assert len(loader) == len(synthetic_dataset.data)
     for item in loader:
         assert len(item) == 1
 
@@ -34,7 +33,7 @@ def test_pytorch_dataloader_batched(synthetic_dataset):
     batch_size = 10
     loader = DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()),
                         batch_size=batch_size, collate_fn=_noop_collate)
-    assert len(loader) == ROWS_COUNT / batch_size
+    assert len(loader) == len(synthetic_dataset.data) / batch_size
     for item in loader:
         assert len(item) == batch_size
 
@@ -42,6 +41,6 @@ def test_pytorch_dataloader_batched(synthetic_dataset):
 def test_pytorch_dataloader_context(synthetic_dataset):
     with DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()),
                     collate_fn=_noop_collate) as loader:
-        assert len(loader) == ROWS_COUNT
+        assert len(loader) == len(synthetic_dataset.data)
         for item in loader:
             assert len(item) == 1


### PR DESCRIPTION
No need to import it in tests. The information is present in the synthetic_dataset itself.