### PR TITLE
Support default transform correctly & make Dataloader return dictionaries and not lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ def _transform_row(mnist_row):
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
     ])
-    return (transform(mnist_row.image), mnist_row.digit)
+    return (transform(mnist_row['image']), mnist_row['digit'])
 
 with DataLoader(Reader('file:///localpath/mnist/train', num_epochs=10),
                 batch_size=64, transform=_transform_row) as train_loader:

--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -91,7 +91,7 @@ def _transform_row(mnist_row):
     # In addition, the petastorm pytorch DataLoader does not distinguish the notion of
     # data or target transform, but that actually gives the user more flexibility
     # to make the desired partial transform, as shown here.
-    return (transform(mnist_row.image), mnist_row.digit)
+    return (transform(mnist_row['image']), mnist_row['digit'])
 
 def main():
     # Training settings

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -27,7 +27,7 @@ class DataLoader(object):
     once more at the very end.
     """
 
-    def __init__(self, reader, batch_size=1, collate_fn=default_collate, transform=lambda *args, **kwargs: None):
+    def __init__(self, reader, batch_size=1, collate_fn=default_collate, transform=None):
         """
         Initializes a data loader object, with a default collate and optional transform functions.
 
@@ -54,7 +54,10 @@ class DataLoader(object):
         """
         batch = []
         for row in self.reader:
-            batch.append(self.transform(row))
+            # Default collate does not work nicely on namedtuples and treat them as lists
+            # Using dict will result in the yielded structures being dicts as well
+            row_as_dict = row._asdict()
+            batch.append(self.transform(row_as_dict) if self.transform else row_as_dict)
             if len(batch) == self.batch_size:
                 yield self.collate_fn(batch)
                 batch = []


### PR DESCRIPTION

Prevoiusly, a code that would create a Dataloader without transform argument would fail,
since the default transform would return None instead of being an identity function.

Also, `default_collate` function implementation does not support namedtuples, as returned by Reader.
Changed the returned types to be dictionaries which are supported ok.