### PR TITLE
Correct way to stop spark

### DIFF
--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -125,7 +125,7 @@ def _main(args):
     generate_petastorm_metadata(spark, args.dataset_url, args.unischema_class)
 
     # Shut down the spark sessions and context
-    spark.sparkContext.stop()
+    spark.stop()
 
 
 def main():

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -120,6 +120,6 @@ def create_test_dataset(tmp_url, rows, num_files=2, spark=None):
     build_rowgroup_index(tmp_url, spark_context, indexers)
 
     if shutdown:
-        spark_context.stop()
+        spark.stop()
 
     return dataset_dicts

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -384,7 +384,7 @@ def test_materialize_dataset_hadoop_config(synthetic_dataset):
     # Other options should return to being unset
     assert hadoop_config.get('parquet.block.size') is None
     assert hadoop_config.get('parquet.block.size.row.check.min') is None
-    spark.sparkContext.stop()
+    spark.stop()
     rmtree(destination)
 
 


### PR DESCRIPTION
Instead of calling .stop() on sqlContext object, we should do it on the main spark session.