### PR TITLE
Speed up processing of small row datasets with ProcessPool

### DIFF
--- a/petastorm/reader_worker.py
+++ b/petastorm/reader_worker.py
@@ -106,8 +106,8 @@ class ReaderWorker(WorkerBase):
         if self._ngram:
             all_cols = self._ngram.form_ngram(data=all_cols, schema=self._schema)
 
-        for item in all_cols:
-            self.publish_func(item)
+        if all_cols:
+            self.publish_func(all_cols)
 
     def _load_rows(self, pq_file, piece, shuffle_row_drop_range):
         """Loads all rows from a piece"""

--- a/petastorm/tests/test_codecs.py
+++ b/petastorm/tests/test_codecs.py
@@ -81,7 +81,7 @@ class ScalarCodecsTest(unittest.TestCase):
         field = UnischemaField(name='field_decimal', numpy_dtype=Decimal, shape=(), codec=codec, nullable=False)
 
         value = Decimal('123.4567')
-        self.assertEqual(codec.decode(field, codec.encode(field, value)), value)
+        self.assertEqual(codec.decode(field, codec.encode(field, value)), str(value))
 
 
 class CompressedImageCodecsTest(unittest.TestCase):

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -122,4 +122,11 @@ def create_test_dataset(tmp_url, rows, num_files=2, spark=None):
     if shutdown:
         spark_context.stop()
 
+    # Reader does not support Decimal fields as return types, so it will be converting all decimals
+    # to strings. We replace all decimals in the returned list of dictionaries to match this behavior
+    for row in dataset_dicts:
+        for k, v in row.items():
+            if isinstance(v, Decimal):
+                row[k] = str(v.normalize())
+
     return dataset_dicts

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -42,7 +42,7 @@ def _check_simple_reader(reader, expected_data):
     for row in reader:
         actual = dict(row._asdict())
         expected = next(d for d in expected_data if d['id'] == actual['id'])
-        np.testing.assert_equal(actual, expected)
+        np.testing.assert_equal(expected, actual)
 
 
 @pytest.mark.parametrize('reader_factory', ALL_READER_FLAVOR_FACTORIES)


### PR DESCRIPTION
We use pyarrow serialization instead of standard pickling. Unfortunatelly, pyarrow serialization
does not support decimals, so we modify the codec to decode decimals always as strings.

Updated all tests to reflect the decimal->string behavior.