### PR TITLE
Adding WeightedSamplingReader class

### DIFF
--- a/docs/autodoc/reader.rst
+++ b/docs/autodoc/reader.rst
@@ -49,3 +49,4 @@ Reader utilities
 ----------------
 
 .. automodule:: petastorm.utils
+.. automodule:: petastorm.sampling_mixer

--- a/petastorm/sampling_mixer.py
+++ b/petastorm/sampling_mixer.py
@@ -1,0 +1,80 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import numpy as np
+
+
+class SamplingMixer(object):
+    """Allows to combine outputs of two or more Reader objects, sampling them with a configurable probability.
+    Complies to the same interfaces as :class:`~petastorm.reader.Reader`, hence
+    :class:`~petastorm.sampling_mixer.SamplingMixer` can be used anywhere the :class:`~petastorm.reader.Reader`
+    can be used."""
+    def __init__(self, readers, probabilities):
+        """The constructor is configured with a list of readers and probabilities. The lists must be the same length.
+        :class:`~petastorm.sampling_mixer.SamplingMixer` implements an iterator interface. Each time a new element
+        is requested, one of the readers is selected, weighted by the matching probability. An element produced by the
+        selected reader is returned.
+
+        The iterator raises StopIteration exception once one of the embedded readers has no more data left.
+
+        The following example shows how a :class:`~petastorm.sampling_mixer.SamplingMixer` can be instantiated
+        with two readers which are sampled with 10% and 90% probabilities respectively.
+
+        >>> from petastorm.sampling_mixer import SamplingMixer
+        >>> from petastorm.reader import Reader
+        >>>
+        >>> with SamplingMixer([Reader('file:///dataset1'), Reader('file:///dataset1')], [0.1, 0.9]) as reader:
+        >>>     new_sample = next(reader)
+
+
+        :param readers: A list of readers. The length of the list must be the same as the length of the
+        ``probabilities`` list.
+        :param probabilities: A list of probabilities. The length of the list must be the same as the length
+          of ``readers`` argument. If the sum of all probability values is not 1.0, it will be automatically
+          normalized.
+        """
+        if len(readers) != len(probabilities):
+            raise ValueError('readers and probabilities are expected to be lists of the same length')
+
+        self._readers = readers
+
+        # Normalize probabilities
+        self._cum_prob = np.cumsum(np.asarray(probabilities, dtype=np.float) / np.sum(probabilities))
+
+    def __len__(self):
+        return sum(len(reader) for reader in self._readers)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        r = np.random.random()
+        reader_index = np.where(r < self._cum_prob)[0][0]
+        return next(self._readers[reader_index])
+
+    def next(self):
+        return self.__next__()
+
+    # Functions needed to treat reader as a context manager
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for reader in self._readers:
+            reader.stop()
+
+        for reader in self._readers:
+            reader.join()

--- a/petastorm/tests/test_sampling_mixer.py
+++ b/petastorm/tests/test_sampling_mixer.py
@@ -1,0 +1,90 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import numpy as np
+import pytest
+import six
+
+from petastorm.predicates import in_lambda
+from petastorm.reader import Reader
+from petastorm.sampling_mixer import SamplingMixer
+from petastorm.test_util.reader_mock import ReaderMock
+from petastorm.unischema import Unischema, UnischemaField
+
+TestSchema = Unischema('TestSchema', [
+    UnischemaField('f1', np.int32, (), None, False),
+])
+
+reader0 = ReaderMock(TestSchema, lambda _: {'f1': 0})
+reader1 = ReaderMock(TestSchema, lambda _: {'f1': 1})
+reader2 = ReaderMock(TestSchema, lambda _: {'f1': 2})
+
+
+def _count_mixed(readers, probabilities, num_of_reads):
+    result = len(probabilities) * [0]
+
+    with SamplingMixer(readers, probabilities) as mixer:
+        for _ in six.moves.xrange(num_of_reads):
+            reader_index = next(mixer).f1
+            result[reader_index] += 1
+
+    return result
+
+
+def test_select_only_one_of_readers():
+    num_of_reads = 1000
+    np.testing.assert_array_equal(_count_mixed([reader0, reader1], [1.0, 0.0], num_of_reads), [num_of_reads, 0])
+    np.testing.assert_array_equal(_count_mixed([reader0, reader1], [0.0, 1.0], num_of_reads), [0, num_of_reads])
+
+    np.testing.assert_array_equal(
+        _count_mixed([reader0, reader1, reader2], [0.0, 1.0, 0.0], num_of_reads), [0, num_of_reads, 0])
+    np.testing.assert_array_equal(
+        _count_mixed([reader0, reader1, reader2], [0.0, 0.0, 1.0], num_of_reads), [0, 0, num_of_reads])
+
+
+def test_not_normalized_probabilities():
+    num_of_reads = 1000
+    mix_10_90 = _count_mixed([reader0, reader1], [10, 90], num_of_reads)
+    np.testing.assert_allclose(mix_10_90, [num_of_reads * 0.1, num_of_reads * 0.9], atol=num_of_reads / 10)
+
+
+def test_mixing():
+    num_of_reads = 1000
+    mix_10_90 = _count_mixed([reader0, reader1], [0.1, 0.9], num_of_reads)
+
+    np.testing.assert_allclose(mix_10_90, [num_of_reads * 0.1, num_of_reads * 0.9], atol=num_of_reads / 10)
+
+    mix_10_50_40 = _count_mixed([reader0, reader1, reader2], [0.1, 0.5, 0.4], num_of_reads)
+    np.testing.assert_allclose(mix_10_50_40, [num_of_reads * 0.1, num_of_reads * 0.5, num_of_reads * 0.4],
+                               atol=num_of_reads / 10)
+
+
+def test_real_reader(synthetic_dataset):
+    readers = [Reader(synthetic_dataset.url, predicate=in_lambda(['id'], lambda id: id % 2 == 0), num_epochs=None),
+               Reader(synthetic_dataset.url, predicate=in_lambda(['id'], lambda id: id % 2 == 1), num_epochs=None)]
+    results = [0, 0]
+    num_of_reads = 300
+    with SamplingMixer(readers, [0.5, 0.5]) as mixer:
+        for _ in six.moves.xrange(num_of_reads):
+            next_id = next(mixer).id % 2
+            results[next_id] += 1
+
+    np.testing.assert_allclose(results, [num_of_reads * 0.5, num_of_reads * 0.5], atol=num_of_reads / 10)
+
+
+def test_bad_arguments():
+    with pytest.raises(ValueError):
+        SamplingMixer([reader1], [0.1, 0.9])


### PR DESCRIPTION
`WeightedSamplingReader` takes a list of Reader objects and probabilities. When iterated over, it returns a mixture of rows returned from the readers. The mixture proportions defined by the probabilities passed to `WeightedSamplingReader` in a constructor.
`WeightedSamplingReader`  implements the same interface as `Reader`.