### PR TITLE
Revert to using the old metadata method by default

### DIFF
--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -43,7 +43,7 @@ spark-submit \\
 '''
 
 
-def generate_petastorm_metadata(spark, dataset_url, unischema_class=None):
+def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_summary_metadata=False):
     """
     Generates metadata necessary to read a petastorm dataset to an existing dataset.
 
@@ -74,18 +74,23 @@ def generate_petastorm_metadata(spark, dataset_url, unischema_class=None):
     # overwriting the metadata to keep row group indexes and the old row group per file index
     arrow_metadata = dataset.common_metadata or None
 
-    with materialize_dataset(spark, dataset_url, schema):
-        # Inside the materialize dataset context we just need to write the metadata file as the schema will
-        # be written by the context manager.
-        # We use the java ParquetOutputCommitter to write the metadata file for the existing dataset
-        # which will read all the footers of the dataset in parallel and merge them.
-        hadoop_config = sc._jsc.hadoopConfiguration()
-        Path = sc._gateway.jvm.org.apache.hadoop.fs.Path
-        parquet_output_committer = sc._gateway.jvm.org.apache.parquet.hadoop.ParquetOutputCommitter
-        parquet_output_committer.writeMetaDataFile(hadoop_config, Path(dataset_url))
+    with materialize_dataset(spark, dataset_url, schema, use_summary_metadata=use_summary_metadata):
+        if use_summary_metadata:
+            # Inside the materialize dataset context we just need to write the metadata file as the schema will
+            # be written by the context manager.
+            # We use the java ParquetOutputCommitter to write the metadata file for the existing dataset
+            # which will read all the footers of the dataset in parallel and merge them.
+            hadoop_config = sc._jsc.hadoopConfiguration()
+            Path = sc._gateway.jvm.org.apache.hadoop.fs.Path
+            parquet_output_committer = sc._gateway.jvm.org.apache.parquet.hadoop.ParquetOutputCommitter
+            parquet_output_committer.writeMetaDataFile(hadoop_config, Path(dataset_url))
 
-    if arrow_metadata:
-        # If there was the old row groups per file key or the row groups index key, add them to the new dataset metadata
+    spark.stop()
+
+    if use_summary_metadata and arrow_metadata:
+        # When calling writeMetaDataFile it will overwrite the _common_metadata file which could have schema information
+        # or row group indexers. Therefore we want to retain this information and will add it to the new
+        # _common_metadata file. If we were using the old legacy metadata method this file wont be deleted
         base_schema = arrow_metadata.schema.to_arrow_schema()
         metadata_dict = base_schema.metadata
         if ROW_GROUPS_PER_FILE_KEY in metadata_dict:
@@ -110,6 +115,9 @@ def _main(args):
                              '"local[W]" (where W is the number of local spark workers, e.g. local[10])')
     parser.add_argument('--spark-driver-memory', type=str, help='The amount of memory the driver process will have',
                         default='4g')
+    parser.add_argument('--use-summary-metadata', action='store_true',
+                        help='Whether to use the parquet summary metadata format.'
+                             ' Not scalable for large amounts of columns and/or row groups.')
     args = parser.parse_args(args)
 
     # Open Spark Session
@@ -122,7 +130,7 @@ def _main(args):
 
     spark = spark_session.getOrCreate()
 
-    generate_petastorm_metadata(spark, args.dataset_url, args.unischema_class)
+    generate_petastorm_metadata(spark, args.dataset_url, args.unischema_class, args.use_summary_metadata)
 
     # Shut down the spark sessions and context
     spark.sparkContext.stop()

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -43,9 +43,6 @@ class DataLoader(object):
         self.collate_fn = collate_fn
         self.transform = transform
 
-    def __len__(self):
-        return (len(self.reader) + self.batch_size - 1) // self.batch_size
-
     def __iter__(self):
         """
         The Data Loader iterator stops the for-loop at the end of each epoch, but a subsequent for-loop

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -317,13 +317,6 @@ class Reader(object):
         logger.warn(warning_message)
         return self._workers_pool.get_results(timeout=timeout)
 
-    def __len__(self):
-        if not self.dataset.metadata or self.dataset.metadata.num_row_groups == 0:
-            raise NotImplementedError("__len__ is only implemented "
-                                      "if dataset has parquet summary files "
-                                      "with row group information")
-        return self.dataset.metadata.num_rows
-
     def __iter__(self):
         return self
 

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -402,10 +402,3 @@ def test_dataset_path_is_a_unicode(synthetic_dataset):
     unicode_in_p23 = synthetic_dataset.url.encode().decode('utf-8')
     with Reader(unicode_in_p23, reader_pool=DummyPool()) as reader:
         next(reader)
-
-
-def test_reader_len(synthetic_dataset):
-    with Reader(synthetic_dataset.url, reader_pool=DummyPool()) as reader:
-        # multiple access yields the same value
-        assert len(reader) == len(synthetic_dataset.data)
-        assert len(reader) == len(synthetic_dataset.data)

--- a/petastorm/tests/test_generate_metadata.py
+++ b/petastorm/tests/test_generate_metadata.py
@@ -6,6 +6,7 @@ import pytest
 
 import pyarrow.parquet as pq
 
+from petastorm.etl.dataset_metadata import PetastormMetadataError
 from petastorm.reader import Reader
 from petastorm.selectors import SingleIndexSelector
 from petastorm.tests.test_common import create_test_dataset, TestSchema
@@ -31,29 +32,7 @@ def _check_reader(path, rowgroup_selector=None):
         [next(reader) for _ in range(10)]
 
 
-def test_regenerate_row_group_metadata(synthetic_dataset, tmpdir):
-    a_moved_path = tmpdir.join('moved').strpath
-    copytree(synthetic_dataset.path, a_moved_path)
-
-    # Make sure we can read dataset before
-    _check_reader(a_moved_path)
-
-    # Delete only the metadata file
-    dataset = pq.ParquetDataset(a_moved_path)
-    os.remove(dataset.metadata_path)
-
-    # Should now raise a value error
-    with pytest.raises(ValueError):
-        _check_reader(a_moved_path)
-
-    # Regenerate the metadata (taking the schema information from the common_metadata which exists)
-    petastorm_generate_metadata._main(['--dataset_url', 'file://{}'.format(a_moved_path)])
-
-    # Reader should now work again with rowgroup selector since it was in original metadata
-    _check_reader(a_moved_path, SingleIndexSelector(TestSchema.id.name, [2, 18]))
-
-
-def test_regenerate_all_metadata(synthetic_dataset, tmpdir):
+def test_regenerate_metadata(synthetic_dataset, tmpdir):
     a_moved_path = tmpdir.join('moved').strpath
     copytree(synthetic_dataset.path, a_moved_path)
 
@@ -62,11 +41,10 @@ def test_regenerate_all_metadata(synthetic_dataset, tmpdir):
 
     # Delete both metadata files
     dataset = pq.ParquetDataset(a_moved_path)
-    os.remove(dataset.metadata_path)
     os.remove(dataset.common_metadata_path)
 
     # Should now raise a value error
-    with pytest.raises(ValueError):
+    with pytest.raises(PetastormMetadataError):
         _check_reader(a_moved_path)
 
     # Regenerate all metadata including unischema information
@@ -79,22 +57,19 @@ def test_regenerate_all_metadata(synthetic_dataset, tmpdir):
     _check_reader(a_moved_path)
 
 
-def test_cannot_find_unischema(synthetic_dataset, tmpdir):
+def test_regenerate_using_row_group_summary_metadata(synthetic_dataset, tmpdir):
     a_moved_path = tmpdir.join('moved').strpath
     copytree(synthetic_dataset.path, a_moved_path)
 
     # Make sure we can read dataset before
     _check_reader(a_moved_path)
 
-    # Delete both metadata files
+    # Regenerate the metadata (taking the schema information from the common_metadata which exists)
+    petastorm_generate_metadata._main(['--dataset_url', 'file://{}'.format(a_moved_path), '--use-summary-metadata'])
+
     dataset = pq.ParquetDataset(a_moved_path)
-    os.remove(dataset.metadata_path)
-    os.remove(dataset.common_metadata_path)
+    # Metadata path should not exist still (should be only _common_metadata)
+    assert dataset.metadata
 
-    # Should now raise a value error
-    with pytest.raises(ValueError):
-        _check_reader(a_moved_path)
-
-    # Regeneration should fail since it cannot find the unischema
-    with pytest.raises(ValueError):
-        petastorm_generate_metadata._main(['--dataset_url', 'file://{}'.format(a_moved_path)])
+    # Reader should now work again with rowgroup selector since it was in original metadata
+    _check_reader(a_moved_path, SingleIndexSelector(TestSchema.id.name, [2, 18]))

--- a/petastorm/tests/test_predicates.py
+++ b/petastorm/tests/test_predicates.py
@@ -119,7 +119,6 @@ def test_predicate_on_single_column(synthetic_dataset):
                     schema_fields=[TestSchema.id2],
                     predicate=in_lambda(['id2'], lambda id2: True),
                     reader_pool=DummyPool())
-    assert len(reader) == len(synthetic_dataset.data)
     counter = 0
     for row in reader:
         counter += 1

--- a/petastorm/tests/test_pytorch_utils.py
+++ b/petastorm/tests/test_pytorch_utils.py
@@ -24,7 +24,6 @@ def _noop_collate(alist):
 
 def test_basic_pytorch_dataloader(synthetic_dataset):
     loader = DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()), collate_fn=_noop_collate)
-    assert len(loader) == len(synthetic_dataset.data)
     for item in loader:
         assert len(item) == 1
 
@@ -33,7 +32,6 @@ def test_pytorch_dataloader_batched(synthetic_dataset):
     batch_size = 10
     loader = DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()),
                         batch_size=batch_size, collate_fn=_noop_collate)
-    assert len(loader) == len(synthetic_dataset.data) / batch_size
     for item in loader:
         assert len(item) == batch_size
 
@@ -41,6 +39,5 @@ def test_pytorch_dataloader_batched(synthetic_dataset):
 def test_pytorch_dataloader_context(synthetic_dataset):
     with DataLoader(Reader(synthetic_dataset.url, reader_pool=DummyPool()),
                     collate_fn=_noop_collate) as loader:
-        assert len(loader) == len(synthetic_dataset.data)
         for item in loader:
             assert len(item) == 1

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -28,6 +28,7 @@ def test_dataset_url_must_be_string():
         Reader(dataset_url=[])
 
 
+@pytest.mark.skip('We no longer know how many rows in each row group')
 def test_normalize_shuffle_partitions(synthetic_dataset):
     dataset = pq.ParquetDataset(synthetic_dataset.path)
     shuffle_options = ShuffleOptions(True, 2)


### PR DESCRIPTION
Since we have needed to do this a few times, lets bring the legacy metadata back for now until we can figure it out more explicitly