### PR TITLE
Rename sampling mixer

### DIFF
--- a/petastorm/tests/test_weighted_sampling_reader.py
+++ b/petastorm/tests/test_weighted_sampling_reader.py
@@ -20,7 +20,7 @@ import six
 
 from petastorm.predicates import in_lambda
 from petastorm.reader import Reader
-from petastorm.sampling_mixer import SamplingMixer
+from petastorm.weighted_sampling_reader import WeightedSamplingReader
 from petastorm.test_util.reader_mock import ReaderMock
 from petastorm.unischema import Unischema, UnischemaField
 
@@ -36,7 +36,7 @@ reader2 = ReaderMock(TestSchema, lambda _: {'f1': 2})
 def _count_mixed(readers, probabilities, num_of_reads):
     result = len(probabilities) * [0]
 
-    with SamplingMixer(readers, probabilities) as mixer:
+    with WeightedSamplingReader(readers, probabilities) as mixer:
         for _ in six.moves.xrange(num_of_reads):
             reader_index = next(mixer).f1
             result[reader_index] += 1
@@ -77,7 +77,7 @@ def test_real_reader(synthetic_dataset):
                Reader(synthetic_dataset.url, predicate=in_lambda(['id'], lambda id: id % 2 == 1), num_epochs=None)]
     results = [0, 0]
     num_of_reads = 300
-    with SamplingMixer(readers, [0.5, 0.5]) as mixer:
+    with WeightedSamplingReader(readers, [0.5, 0.5]) as mixer:
         for _ in six.moves.xrange(num_of_reads):
             next_id = next(mixer).id % 2
             results[next_id] += 1
@@ -87,4 +87,4 @@ def test_real_reader(synthetic_dataset):
 
 def test_bad_arguments():
     with pytest.raises(ValueError):
-        SamplingMixer([reader1], [0.1, 0.9])
+        WeightedSamplingReader([reader1], [0.1, 0.9])

--- a/petastorm/weighted_sampling_reader.py
+++ b/petastorm/weighted_sampling_reader.py
@@ -17,26 +17,26 @@ from __future__ import division
 import numpy as np
 
 
-class SamplingMixer(object):
+class WeightedSamplingReader(object):
     """Allows to combine outputs of two or more Reader objects, sampling them with a configurable probability.
     Complies to the same interfaces as :class:`~petastorm.reader.Reader`, hence
-    :class:`~petastorm.sampling_mixer.SamplingMixer` can be used anywhere the :class:`~petastorm.reader.Reader`
-    can be used."""
+    :class:`~petastorm.weighted_sampling_reader.WeightedSamplingReader` can be used anywhere the
+    :class:`~petastorm.reader.Reader` can be used."""
     def __init__(self, readers, probabilities):
         """The constructor is configured with a list of readers and probabilities. The lists must be the same length.
-        :class:`~petastorm.sampling_mixer.SamplingMixer` implements an iterator interface. Each time a new element
-        is requested, one of the readers is selected, weighted by the matching probability. An element produced by the
-        selected reader is returned.
+        :class:`~petastorm.weighted_sampling_reader.WeightedSamplingReader` implements an iterator interface. Each time
+        a new element is requested, one of the readers is selected, weighted by the matching probability. An element
+        produced by the selected reader is returned.
 
         The iterator raises StopIteration exception once one of the embedded readers has no more data left.
 
-        The following example shows how a :class:`~petastorm.sampling_mixer.SamplingMixer` can be instantiated
-        with two readers which are sampled with 10% and 90% probabilities respectively.
+        The following example shows how a :class:`~petastorm.weighted_sampling_reader.WeightedSamplingReader` can be
+        instantiated with two readers which are sampled with 10% and 90% probabilities respectively.
 
-        >>> from petastorm.sampling_mixer import SamplingMixer
+        >>> from petastorm.weighted_sampling_reader import WeightedSamplingReader
         >>> from petastorm.reader import Reader
         >>>
-        >>> with SamplingMixer([Reader('file:///dataset1'), Reader('file:///dataset1')], [0.1, 0.9]) as reader:
+        >>> with WeightedSamplingReader([Reader('file:///dataset1'), Reader('file:///dataset1')], [0.1, 0.9]) as reader:
         >>>     new_sample = next(reader)
 
 


### PR DESCRIPTION
Accidentally landed a `SamplingMixer` before it was renamed to `WeightedSamplingReader`. This PR renames the class to its proper name.