### PR TITLE
Try to speedup CI build by using pytest-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,16 @@ before_script:
 script:
   - pylint --rcfile=.pylintrc petastorm examples -f parseable -r n
   # Ignore two pytorch tests to prevent static-TLS-caused torch-import seg-fault
-  - pytest -v --cov=./ --trace-config
+  # Run first tests that can run in parallel
+  - pytest -nauto -m "not serial" -v --cov=./ --trace-config
     --ignore=examples/mnist/tests/test_generate_mnist_dataset.py
     --ignore=petastorm/tests/test_pytorch_utils.py
+
+  # Now run the tests that require serial run
+  - pytest -m "serial" -v --cov=./ --trace-config
+    --ignore=examples/mnist/tests/test_generate_mnist_dataset.py
+    --ignore=petastorm/tests/test_pytorch_utils.py
+
   # Run the pytorch tests separately, in this order, but accumulate code coverage data
   # Temporary disabled until we figure out (a) segfaults in the first test with `import torch`,
   # and (b) hanging in `test_read_mnist_dataset`

--- a/petastorm/hdfs/tests/test_hdfs_namenode.py
+++ b/petastorm/hdfs/tests/test_hdfs_namenode.py
@@ -19,6 +19,7 @@ import unittest
 from shutil import rmtree
 from tempfile import mkdtemp
 
+import pytest
 from pyarrow.lib import ArrowIOError
 
 from petastorm.hdfs.namenode import HdfsNamenodeResolver, HdfsConnector, \
@@ -51,6 +52,7 @@ class MockHadoopConfiguration(object):
         self._dict[key] = val
 
 
+@pytest.mark.serial
 class HdfsNamenodeResolverTest(unittest.TestCase):
     def setUp(self):
         """Initializes a mock hadoop config and a namenode resolver instance, for convenience."""
@@ -120,6 +122,7 @@ class HdfsNamenodeResolverTest(unittest.TestCase):
             self.suj.resolve_hdfs_name_service(HC.WARP_TURTLE)
 
 
+@pytest.mark.serial
 class EnvBasedHadoopConfigurationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -255,6 +258,7 @@ class MockHdfs(object):
         """
         The Mock HDFS simply calls check_failover, regardless of the filesystem operator invoked.
         """
+
         def op(*args, **kwargs):
             """ Mock operator """
             return self._check_failovers()
@@ -330,6 +334,7 @@ class MockHdfsConnector(HdfsConnector):
 
 class HdfsConnectorTest(unittest.TestCase):
     """Check correctness of connecting to a list of namenodes. """
+
     @classmethod
     def setUpClass(cls):
         """Initializes a mock HDFS namenode connector to track connection attempts."""
@@ -380,6 +385,7 @@ class HAHdfsClientTest(unittest.TestCase):
     The HDFS testing functions are enumerated explicitly below for simplicity and clarity, but it
     should impose but a minute maintenance overhead, since MockHdfs class requires no enumeration.
     """
+
     @classmethod
     def setUpClass(cls):
         """Initializes namenodes list and mock HDFS namenode connector."""

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ EXTRA_REQUIRE = {
     'tf': ['tensorflow>=1.4.0'],
     'tf_gpu': ['tensorflow-gpu>=1.4.0'],
     'test' : ['opencv-python>=3.2.0.6', 'pytest>=3.0.0', 'pytest-cov>=2.5.1',
-              'Pillow>=3.0', 'pylint>=1.9', 'codecov>=2.0.15'],
+              'Pillow>=3.0', 'pylint>=1.9', 'codecov>=2.0.15', 'pytest-xdist>=1.13'],
     'torch': ['torchvision>=0.2.1'],
 }
 


### PR DESCRIPTION
Tests that fail to run in parallel due to global state are marked with `@pytest.mark.serial` mark.
We invoke `pytest` twice: once for tests that can run in parallel with `-nauto` switch, and the second time we run only tests that have to be serialized.