### PR TITLE
Resurrect Decimal type and make pyarrow.serialize optional

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -20,18 +20,18 @@ transitively to parquet files.
 NOTE: Due to the way unischema is stored alongside dataset (with pickling), changing any of these codecs class names
 and fields can result in reader breakages.
 """
-import decimal
+
+from abc import abstractmethod
+from io import BytesIO
 
 import cv2
-from io import BytesIO
-from abc import abstractmethod
-
 import numpy as np
 from pyspark.sql.types import BinaryType, LongType, IntegerType, ShortType, ByteType, StringType
 
 
 class DataframeColumnCodec(object):
     """The abstract base class of codecs."""
+
     @abstractmethod
     def encode(self, unischema_field, array):
         raise RuntimeError('Abstract method was called')
@@ -187,10 +187,7 @@ class ScalarCodec(DataframeColumnCodec):
         # Tensorflow does not support Decimal types neither. We convert all decimals to
         # strings hence prevent Decimals from getting into anywhere in the reader. We may
         # choose to resurrect Decimals support in the future.
-        if isinstance(value, decimal.Decimal):
-            return str(value.normalize())
-        else:
-            return unischema_field.numpy_dtype(value)
+        return unischema_field.numpy_dtype(value)
 
     def spark_dtype(self):
         return self._spark_type

--- a/petastorm/tests/test_codecs.py
+++ b/petastorm/tests/test_codecs.py
@@ -81,7 +81,7 @@ class ScalarCodecsTest(unittest.TestCase):
         field = UnischemaField(name='field_decimal', numpy_dtype=Decimal, shape=(), codec=codec, nullable=False)
 
         value = Decimal('123.4567')
-        self.assertEqual(codec.decode(field, codec.encode(field, value)), str(value))
+        self.assertEqual(codec.decode(field, codec.encode(field, value)), value)
 
 
 class CompressedImageCodecsTest(unittest.TestCase):

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -122,11 +122,4 @@ def create_test_dataset(tmp_url, rows, num_files=2, spark=None):
     if shutdown:
         spark.stop()
 
-    # Reader does not support Decimal fields as return types, so it will be converting all decimals
-    # to strings. We replace all decimals in the returned list of dictionaries to match this behavior
-    for row in dataset_dicts:
-        for k, v in row.items():
-            if isinstance(v, Decimal):
-                row[k] = str(v.normalize())
-
     return dataset_dicts

--- a/petastorm/tests/test_ngram_end_to_end.py
+++ b/petastorm/tests/test_ngram_end_to_end.py
@@ -32,8 +32,11 @@ from petastorm.workers_pool.dummy_pool import DummyPool
 
 # Tests in this module will run once for each entry in the READER_FACTORIES
 # pylint: disable=unnecessary-lambda
+from petastorm.workers_pool.process_pool import ProcessPool
+
 READER_FACTORIES = [
     lambda url, **kwargs: Reader(url, reader_pool=DummyPool(), **kwargs),
+    lambda url, **kwargs: Reader(url, reader_pool=ProcessPool(1), **kwargs),
     lambda url, **kwargs: ReaderV2(url, loader_pool=SameThreadExecutor(), decoder_pool=SameThreadExecutor(), **kwargs),
 ]
 


### PR DESCRIPTION
Replacing Decimal with strings at the codec level was a bad idea. It broke a bunch of existing code.
Among others, it also broke ngrams which were relying on Decimal field for threashold checks.

In this commit, we add pyarrow_serliaze optional argument to the ProcessPool constructor, so a user
that needs pyarrow fast serialization, but is willing to sacrifice some types that can be used
in a Unischema can get faster serialization.