### PR TITLE
Undefined name: args.pool_type --> pool_type in throughput.py

### DIFF
--- a/petastorm/benchmark/throughput.py
+++ b/petastorm/benchmark/throughput.py
@@ -262,7 +262,7 @@ def _create_worker_pool(pool_type, workers_count, profiling_enabled):
     elif pool_type == WorkerPoolType.NONE:
         worker_pool = DummyPool()
     else:
-        raise ValueError('Supported pool types are thread, process or dummy. Got {}.'.format(args.pool_type))
+        raise ValueError('Supported pool types are thread, process or dummy. Got {}.'.format(pool_type))
     return worker_pool
 
 


### PR DESCRIPTION
__args__ is an _undefined name_ in this context which will probably raise NameError at runtime.

__pool_type__ is an argument to this function so this PR recommends using that instead of __args.pool_type__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/uber/petastorm on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./petastorm/benchmark/throughput.py:265:94: F821 undefined name 'args'
        raise ValueError('Supported pool types are thread, process or dummy. Got {}.'.format(args.pool_type))
                                                                                             ^
1     F821 undefined name 'args'
1
```