### PR TITLE
Travis CI: Add Python 3.7 and flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ python:
 matrix:
   include:
     - python: '3.7'
-      sudo: required  # equired for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
   allow_failures:
     - python: '3.7'  # Until Python 3.7 support is added to https://pypi.org/project/pyarrow
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
   include:
     - python: '3.7'
       sudo: required  # equired for Python 3.7 (travis-ci/travis-ci#9069)
+  allow_failures:
+    - python: '3.7'  # Until Python 3.7 support is added to https://pypi.org/project/pyarrow
 
 install:
   # Upgrade pip to avoid weird failures, such as failing to install torchvision

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ cache: pip
 python:
   - '2.7'
   - '3.6'
+matrix:
+  include:
+    - python: '3.7'
+      sudo: required  # equired for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
   # Upgrade pip to avoid weird failures, such as failing to install torchvision
@@ -32,6 +36,11 @@ install:
 before_script:
   # enable core dumps
   - ulimit -c unlimited -S
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   # Build documentation


### PR DESCRIPTION
Fixes #175
* Add Python 3.7 in alignment with travis-ci/travis-ci#9069
* Add [flake8](http://flake8.pycqa.org) tests as discussed at https://github.com/uber/petastorm/pull/174#issuecomment-423771436