### PR TITLE
Batch decoding tasks for decoding. Optionally use `pyarrow.serialize`

### DIFF
--- a/petastorm/benchmark/cli.py
+++ b/petastorm/benchmark/cli.py
@@ -75,6 +75,11 @@ def _parse_args(args):
     parser.add_argument('--experimental-decoders-count', type=int, default=3, required=False,
                         help='Number of decoder threads/processes. Used only if --experimental-reader is set.')
 
+    parser.add_argument('--pyarrow-serialize', action='store_true', required=False,
+                        help='When specified, faster pyarrow.serialize library is used. However, it does not support '
+                             'all data types and implicitly converts some datatypes (e.g. int64->int32) which may'
+                             'trigger errors when reading the data from Tensorflow.')
+
     parser.add_argument('-vv', action='store_true', default=False, help='Sets logging level to DEBUG.')
     parser.add_argument('-v', action='store_true', default=False, help='Sets logging level to INFO.')
 
@@ -101,14 +106,15 @@ def _main(args):
                                        loaders_count=args.workers_count,
                                        decoders_count=args.experimental_decoders_count, read_method=args.read_method,
                                        shuffling_queue_size=args.shuffling_queue_size,
-                                       min_after_dequeue=args.min_after_dequeue)
+                                       min_after_dequeue=args.min_after_dequeue,
+                                       pyarrow_serialize=args.pyarrow_serialize)
 
     else:
         results = reader_throughput(args.dataset_path, args.field_regex, warmup_cycles_count=args.warmup_cycles,
                                     measure_cycles_count=args.measure_cycles, pool_type=args.pool_type,
                                     loaders_count=args.workers_count, profile_threads=args.profile_threads,
                                     read_method=args.read_method, shuffling_queue_size=args.shuffling_queue_size,
-                                    min_after_dequeue=args.min_after_dequeue)
+                                    min_after_dequeue=args.min_after_dequeue, pyarrow_serialize=args.pyarrow_serialize)
 
     logger.info('Done')
     print('Average sample read rate: {:1.2f} samples/sec; RAM {:1.2f} MB (rss); '

--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -20,7 +20,7 @@ transitively to parquet files.
 NOTE: Due to the way unischema is stored alongside dataset (with pickling), changing any of these codecs class names
 and fields can result in reader breakages.
 """
-
+from decimal import Decimal
 from abc import abstractmethod
 from io import BytesIO
 
@@ -214,3 +214,24 @@ def _is_compliant_shape(a, b):
             if a[i] != b[i]:
                 return False
     return True
+
+
+def decimal_to_str(data):
+    """Iterates over a nested structure of lists and dictionaries while substituting all Decimal instances with
+    normalized string representation of Decimals.
+
+    Modification is done in-place.
+
+    :param data: A nested structure of lists and dictionaries
+    :return: None
+    """
+    if isinstance(data, list):
+        for row in data:
+            decimal_to_str(row)
+    elif isinstance(data, dict):
+        for k, v in data.items():
+            if isinstance(v, dict):
+                decimal_to_str(v)
+            else:
+                if isinstance(v, Decimal):
+                    data[k] = str(v.normalize())

--- a/petastorm/reader_impl/pyarrow_serializer.py
+++ b/petastorm/reader_impl/pyarrow_serializer.py
@@ -1,0 +1,28 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyarrow
+
+from petastorm.codecs import decimal_to_str
+
+
+class PyArrowSerializer(object):
+
+    def serialize(self, rows):
+        # pyarrow.serialize does not support decimals.
+        decimal_to_str(rows)
+        return pyarrow.serialize(rows).to_buffer()
+
+    def deserialize(self, serialized_rows):
+        return pyarrow.read_serialized(serialized_rows).deserialize()

--- a/petastorm/reader_impl/same_thread_executor.py
+++ b/petastorm/reader_impl/same_thread_executor.py
@@ -23,6 +23,15 @@ class SameThreadExecutor(Executor):
     """A mock executor. Guarantees stable order of future evaluations: a submitted future is
     evaluated immediately as part of submit implementation."""
 
+    def __init__(self):
+        super(SameThreadExecutor, self).__init__()
+
+        # For now we define _max_workers and polymorphically with ThreadPoolExecutor and ProcessPoolExecutor in
+        # worker_loop. We should not rely on private _max_workers for that, but first we need to refactor
+        # ReaderV2 so we would know during construction of the reader what is the number of workers. Currently we
+        # just get an *PoolExecutor instance which don't have a public API for that.
+        self._max_workers = 1
+
     def submit(self, fn, *args, **kwargs):
         future = Future()
         future.set_result(fn(*args, **kwargs))

--- a/petastorm/reader_impl/shuffling_buffer.py
+++ b/petastorm/reader_impl/shuffling_buffer.py
@@ -153,7 +153,7 @@ class RandomShufflingBuffer(ShufflingBufferBase):
         expected_size = self._size + len(items)
         maximal_capacity = self._shuffling_queue_capacity + self._extra_capacity
         if expected_size > maximal_capacity:
-            raise RuntimeError('Attempt to enqueue more elements that the capacity allows. '
+            raise RuntimeError('Attempt to enqueue more elements than the capacity allows. '
                                'Current size: {}, new size {}, maximum allowed: {}'.format(self._size, expected_size,
                                                                                            maximal_capacity))
         self._items[self._size:self._size + len(items)] = items

--- a/petastorm/reader_impl/worker_loop.py
+++ b/petastorm/reader_impl/worker_loop.py
@@ -21,23 +21,19 @@ from collections import Counter
 from time import sleep, time
 from traceback import format_exception
 
-from six.moves import queue
-
 logger = logging.getLogger(__name__)
 
 CHUNK_DECODING_SIZE = 10
 
 _MAX_IN_LOADING_QUEUE_SIZE = 14
 _MAX_IN_DECODING_QUEUE_SIZE = 14
-_LOOP_IDLE_TIME_SEC = 0.001  # 10 ms
-
-_OUTPUT_QUEUE_SIZE = 30
+_LOOP_IDLE_TIME_SEC = 0.01  # 10 ms
 
 
 class RateCalculator(object):
     def __init__(self, name):
         self._name = name
-        self.rate = None
+        self.rate = -1
         self._last_measured_time = None
         self._last_count = 0
 
@@ -63,12 +59,12 @@ class EOFSentinel(object):
     pass
 
 
-def _decode_row_dispatcher(decoder, row, row_serializer):
-    decoded_row = decoder.decode(row)
+def _decode_rows_dispatcher(decoder, rows, row_serializer):
+    decoded_rows = decoder.decode(rows)
     if row_serializer:
-        return row_serializer.serialize(decoded_row)
+        return row_serializer.serialize(decoded_rows)
     else:
-        return decoded_row
+        return decoded_rows
 
 
 class WorkerLoopError(Exception):
@@ -86,8 +82,39 @@ def dispatch_decode(decoder, shuffled):
     return decoder.decode(shuffled)
 
 
-def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, shuffling_queue, output_queue,
-                stop_event, row_serializer, stats):
+def _x(blocking):
+    return 'X' if blocking else '-'
+
+
+def _render_stats(stats):
+    now = time()
+
+    last_report = _render_stats.last_report if hasattr(_render_stats, 'last_report') else 0
+    # print(hasattr(_render_stats, 'last_report'), last_report)
+
+    if last_report + 1.0 < now:
+        stats_string = \
+            ('E{} ' +
+             'L:{}|{} ' +
+             'S:{}|{}|{}|{} ' +
+             'D:{}|{}|{}|{} ' +
+             'O:{}|{}|{}|{}').format(_x(stats['epochs_ended']),
+                                     _x(stats['loader_full']), stats['loader_rate'],
+                                     _x(stats['shuffling_can_add']), stats['shuffling_size'],
+                                     stats['shuffling_rows_retrieved_rate'], _x(stats['shuffling_can_retrieve']),
+                                     _x(stats['decoding_full']), stats['chunk_decoding_size'],
+                                     stats['decoding_in_process'], stats['decoder_batches_read'],
+                                     _x(stats['output_full']), stats['output_queue_size'],
+                                     stats['output_rows_put_rate'], stats['output_rows_put'])
+
+        logger.debug(stats_string)
+
+        _render_stats.last_report = now
+    # print('2', hasattr(_render_stats, 'last_report'), last_report)
+
+
+def worker_loop(epochs_generator, schema, loading_pool, loader, decoding_pool, decoder, shuffling_queue, output_queue,
+                stop_event, row_serializer, target_output_queue_size, stats):
     # Possibly infinite loop driven by row-group ventilation logic (infinite if epochs=inf)
     in_loading_futures = []
     in_decoding = []
@@ -95,7 +122,9 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
     if not isinstance(stats, Counter):
         raise ValueError('stats argument is expected to be a collections.Counter')
 
-    chunk_decoding_size = max(1, decoding_pool._max_workers / _OUTPUT_QUEUE_SIZE)
+    # This is the size of the group that would be sent to the decoder. We update it later, when we know the
+    # row-group size
+    chunk_decoding_size = 50
 
     try:
         epochs_iterator = iter(epochs_generator())
@@ -129,12 +158,15 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             # infinite epochs.
             if rowgroup_spec is not None and len(in_loading_futures) < _MAX_IN_LOADING_QUEUE_SIZE:
                 in_loading_futures.append(loading_pool.submit(loader.load, rowgroup_spec))
-                stats['0_rowgroups_scheduled_for_loading'] += 1
+                stats['loader_total_rowgroup_scheduled'] += 1
 
                 try:
                     rowgroup_spec = next(epochs_iterator)
+                    stats['epochs_ended'] = False
                 except StopIteration:
+                    stats['epochs_ended'] = True
                     rowgroup_spec = None
+            stats['loader_full'] = len(in_loading_futures) >= _MAX_IN_LOADING_QUEUE_SIZE
 
             # 2. Readout what was already loaded and enqueue loaded rows into a shuffling queue
             # ---------------------------------------------------------------------------------
@@ -147,8 +179,13 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
                 try:
                     loaded_future = next(loaded_futures)
                     loaded_future_result = loaded_future.result()
-                    stats['rows_loaded'] += len(loaded_future_result)
-                    load_rate.update(stats['rows_loaded'])
+
+                    # Not necessary an optimal choice of chunk_decoding_size, but should handle the cases of
+                    # large rowgroups with many small records
+                    stats['chunk_decoding_size'] = chunk_decoding_size
+
+                    stats['loader_rows_loaded'] += len(loaded_future_result)
+                    load_rate.update(stats['loader_rows_loaded'])
                     shuffling_queue.add_many(loaded_future_result)
 
                     # Done processing, remove from the queue. 'remove' on the list is ok since we cap the list
@@ -157,13 +194,19 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
                 except (concurrent.futures.TimeoutError, StopIteration):
                     break
 
+            stats['shuffling_can_add'] = shuffling_queue.can_add()
+
             # 3. Read from the shuffling queue and submit decoding tasks to decoding executor
             # ---------------------------------------------------------------------------------
             while shuffling_queue.can_retrieve() and len(in_decoding) < _MAX_IN_DECODING_QUEUE_SIZE:
                 shuffled = shuffling_queue.retrieve_many(chunk_decoding_size)
-                stats['rows_read_from_shuffling_queue'] += len(shuffled)
-                from_shuffling.update(stats['rows_read_from_shuffling_queue'])
-                in_decoding.append(decoding_pool.submit(_decode_row_dispatcher, decoder, shuffled, row_serializer))
+                stats['shuffling_rows_retrieved'] += len(shuffled)
+                stats['shuffling_size'] = shuffling_queue.size
+                from_shuffling.update(stats['shuffling_rows_retrieved'])
+                in_decoding.append(decoding_pool.submit(_decode_rows_dispatcher, decoder, shuffled, row_serializer))
+
+            stats['shuffling_can_retrieve'] = shuffling_queue.can_retrieve()
+            stats['decoding_full'] = len(in_decoding) >= _MAX_IN_DECODING_QUEUE_SIZE
 
             # 4. Read completed decoding futures and put the results into the final output queue
             # ---------------------------------------------------------------------------------
@@ -180,34 +223,42 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             while True:
                 try:
                     next_decoded = next(decoded)
-                    stats['row_batches_read_from_decoder'] += 1
+                    stats['decoder_batches_read'] += 1
                     already_decoded.add(next_decoded)
                 except (concurrent.futures.TimeoutError, StopIteration):
                     break
 
-            stats['in_decoding_size'] = len(in_decoding)
+            stats['decoding_batches_in_process'] = len(in_decoding)
+            stats['decoding_results_ready'] = len(already_decoded) > 0
 
             updated_in_decoding = []
-            for i, was_decoding in enumerate(in_decoding):
-                if was_decoding in already_decoded:
-                    stats['rows_written_to_output_queue'] += 1
-                    while not stop_event.is_set():
-                        try:
-                            buffer = was_decoding.result()
-                            was_decoding_result = row_serializer.deserialize(buffer) if row_serializer else buffer
+            if len(already_decoded) > 0:
+                for i, was_decoding in enumerate(in_decoding):
+                    if output_queue.qsize() * chunk_decoding_size < target_output_queue_size:
+                        stats['output_full'] = False
+                        if was_decoding in already_decoded:
+                            result_buffer = was_decoding.result()
+                            if row_serializer:
+                                was_decoding_result = row_serializer.deserialize(result_buffer)
+                            else:
+                                was_decoding_result = result_buffer
+                            stats['output_batches_put'] += 1
+                            stats['output_rows_put'] += len(was_decoding_result)
                             output_queue.put(was_decoding_result, block=False)
-                            stats['rows_written_to_output_queue'] += len(was_decoding_result)
-                            from_decoding.update(stats['rows_written_to_output_queue'])
-                            break
-                        except queue.Full:
-                            raise RuntimeError('Do not set Queue\'s maxsize. The size of the queue is managed by '
-                                               'worker_loop by design')
-                else:
-                    updated_in_decoding.append(in_decoding[i])
+                            from_decoding.update(stats['output_rows_put'])
+                        else:
+                            updated_in_decoding.append(in_decoding[i])
+                    else:
+                        stats['output_full'] = True
+                        updated_in_decoding.append(in_decoding[i])
 
-            in_decoding = updated_in_decoding
-            stats['output_queue_size'] = output_queue.qsize()
-            stats['in_decoding_size'] = len(in_decoding)
+                in_decoding = updated_in_decoding
+                stats['output_queue_size'] = output_queue.qsize()
+                stats['decoding_in_process'] = len(in_decoding)
+            stats['loader_rate'] = load_rate.rate
+            stats['shuffling_rows_retrieved_rate'] = from_shuffling.rate
+            stats['output_rows_put_rate'] = from_decoding.rate
+            _render_stats(stats)
             sleep(_LOOP_IDLE_TIME_SEC)
 
         # If we were ordered to stop, better not write the sentinel out since the queue can be full

--- a/petastorm/reader_impl/worker_loop.py
+++ b/petastorm/reader_impl/worker_loop.py
@@ -11,21 +11,50 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import division
+
+import concurrent.futures
 import logging
 import sys
 import traceback
 from collections import Counter
-from time import sleep
+from time import sleep, time
 from traceback import format_exception
 
-import concurrent.futures
 from six.moves import queue
 
 logger = logging.getLogger(__name__)
 
+CHUNK_DECODING_SIZE = 10
+
 _MAX_IN_LOADING_QUEUE_SIZE = 14
 _MAX_IN_DECODING_QUEUE_SIZE = 14
-_LOOP_IDLE_TIME_SEC = 0.001  # 1 ms
+_LOOP_IDLE_TIME_SEC = 0.001  # 10 ms
+
+_OUTPUT_QUEUE_SIZE = 30
+
+
+class RateCalculator(object):
+    def __init__(self, name):
+        self._name = name
+        self.rate = None
+        self._last_measured_time = None
+        self._last_count = 0
+
+    def update(self, count):
+        now = time()
+        if not self._last_measured_time:
+            self._last_measured_time = now
+            self._last_count = count
+
+        elif self._last_measured_time + 2.0 < now:
+            interval = now - self._last_measured_time
+            self.rate = (count - self._last_count) / interval
+            self._last_measured_time = now
+            self._last_count = count
+
+    def __str__(self):
+        return '{}: {} fps'.format(self._name, self.rate)
 
 
 class EOFSentinel(object):
@@ -34,8 +63,12 @@ class EOFSentinel(object):
     pass
 
 
-def _decode_row_dispatcher(decoder, row):
-    return decoder.decode(row)
+def _decode_row_dispatcher(decoder, row, row_serializer):
+    decoded_row = decoder.decode(row)
+    if row_serializer:
+        return row_serializer.serialize(decoded_row)
+    else:
+        return decoded_row
 
 
 class WorkerLoopError(Exception):
@@ -49,14 +82,20 @@ class WorkerLoopError(Exception):
 
 
 # Runs in a separate thread
+def dispatch_decode(decoder, shuffled):
+    return decoder.decode(shuffled)
+
+
 def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, shuffling_queue, output_queue,
-                stop_event, stats):
+                stop_event, row_serializer, stats):
     # Possibly infinite loop driven by row-group ventilation logic (infinite if epochs=inf)
     in_loading_futures = []
     in_decoding = []
 
     if not isinstance(stats, Counter):
         raise ValueError('stats argument is expected to be a collections.Counter')
+
+    chunk_decoding_size = max(1, decoding_pool._max_workers / _OUTPUT_QUEUE_SIZE)
 
     try:
         epochs_iterator = iter(epochs_generator())
@@ -66,6 +105,10 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             rowgroup_spec = next(epochs_iterator)
         except StopIteration:
             rowgroup_spec = None
+
+        load_rate = RateCalculator('load')
+        from_shuffling = RateCalculator('from_shuffling')
+        from_decoding = RateCalculator('from_decoding')
 
         # Continue iterating until we have some data in one of the queues connecting loader/shuffling-queue/decoder or
         # we still have some rowgroup_specs to process
@@ -86,8 +129,7 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             # infinite epochs.
             if rowgroup_spec is not None and len(in_loading_futures) < _MAX_IN_LOADING_QUEUE_SIZE:
                 in_loading_futures.append(loading_pool.submit(loader.load, rowgroup_spec))
-                stats['rowgroups_scheduled_for_loading'] += 1
-                stats['in_loading_queue_len'] = len(in_loading_futures)
+                stats['0_rowgroups_scheduled_for_loading'] += 1
 
                 try:
                     rowgroup_spec = next(epochs_iterator)
@@ -106,7 +148,7 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
                     loaded_future = next(loaded_futures)
                     loaded_future_result = loaded_future.result()
                     stats['rows_loaded'] += len(loaded_future_result)
-                    stats['shuffling_buffer_size'] = shuffling_queue.size
+                    load_rate.update(stats['rows_loaded'])
                     shuffling_queue.add_many(loaded_future_result)
 
                     # Done processing, remove from the queue. 'remove' on the list is ok since we cap the list
@@ -118,10 +160,10 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             # 3. Read from the shuffling queue and submit decoding tasks to decoding executor
             # ---------------------------------------------------------------------------------
             while shuffling_queue.can_retrieve() and len(in_decoding) < _MAX_IN_DECODING_QUEUE_SIZE:
-                shuffled = shuffling_queue.retrieve()
-                stats['rows_read_from_shuffling_queue'] += 1
-                in_decoding.append(decoding_pool.submit(_decode_row_dispatcher, decoder, shuffled))
-                stats['in_decoding_queue_len'] = len(in_decoding)
+                shuffled = shuffling_queue.retrieve_many(chunk_decoding_size)
+                stats['rows_read_from_shuffling_queue'] += len(shuffled)
+                from_shuffling.update(stats['rows_read_from_shuffling_queue'])
+                in_decoding.append(decoding_pool.submit(_decode_row_dispatcher, decoder, shuffled, row_serializer))
 
             # 4. Read completed decoding futures and put the results into the final output queue
             # ---------------------------------------------------------------------------------
@@ -138,27 +180,34 @@ def worker_loop(epochs_generator, loading_pool, loader, decoding_pool, decoder, 
             while True:
                 try:
                     next_decoded = next(decoded)
-                    stats['rows_read_from_decoder'] += 1
+                    stats['row_batches_read_from_decoder'] += 1
                     already_decoded.add(next_decoded)
                 except (concurrent.futures.TimeoutError, StopIteration):
                     break
 
-            # follow the order of futures in the `in_decoding` list
+            stats['in_decoding_size'] = len(in_decoding)
+
             updated_in_decoding = []
             for i, was_decoding in enumerate(in_decoding):
                 if was_decoding in already_decoded:
                     stats['rows_written_to_output_queue'] += 1
                     while not stop_event.is_set():
                         try:
-                            output_queue.put(was_decoding.result(), block=False)
+                            buffer = was_decoding.result()
+                            was_decoding_result = row_serializer.deserialize(buffer) if row_serializer else buffer
+                            output_queue.put(was_decoding_result, block=False)
+                            stats['rows_written_to_output_queue'] += len(was_decoding_result)
+                            from_decoding.update(stats['rows_written_to_output_queue'])
                             break
                         except queue.Full:
-                            sleep(_LOOP_IDLE_TIME_SEC)
+                            raise RuntimeError('Do not set Queue\'s maxsize. The size of the queue is managed by '
+                                               'worker_loop by design')
                 else:
                     updated_in_decoding.append(in_decoding[i])
 
             in_decoding = updated_in_decoding
             stats['output_queue_size'] = output_queue.qsize()
+            stats['in_decoding_size'] = len(in_decoding)
             sleep(_LOOP_IDLE_TIME_SEC)
 
         # If we were ordered to stop, better not write the sentinel out since the queue can be full

--- a/petastorm/tests/test_benchmark.py
+++ b/petastorm/tests/test_benchmark.py
@@ -41,6 +41,11 @@ def test_tf_thread_pool_run(synthetic_dataset):
                       pool_type=WorkerPoolType.THREAD, loaders_count=1, read_method=ReadMethod.TF)
 
 
+def test_tf_dataset_thread_pool_run(synthetic_dataset):
+    reader_throughput(synthetic_dataset.url, ['id', 'id2'], warmup_cycles_count=5, measure_cycles_count=5,
+                      pool_type=WorkerPoolType.THREAD, loaders_count=1, read_method=ReadMethod.TF_DATASET)
+
+
 def test_pure_python_thread_pool_run(synthetic_dataset):
     # Use a regex to match field name ('i.' instead of 'id')
     reader_throughput(synthetic_dataset.url, ['i.'], warmup_cycles_count=5, measure_cycles_count=5,
@@ -67,6 +72,12 @@ def test_tf_thread_pool_run_experimental(synthetic_dataset):
     reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
                          measure_cycles_count=5, pool_type=WorkerPoolType.THREAD, loaders_count=1,
                          read_method=ReadMethod.TF)
+
+
+def test_tf_dataset_thread_pool_run_experimental(synthetic_dataset):
+    reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
+                         measure_cycles_count=5, pool_type=WorkerPoolType.THREAD, loaders_count=1,
+                         read_method=ReadMethod.TF_DATASET)
 
 
 def test_tf_thread_pool_run_experimental_with_pyarrow_serialize(synthetic_dataset):

--- a/petastorm/tests/test_benchmark.py
+++ b/petastorm/tests/test_benchmark.py
@@ -30,6 +30,12 @@ def test_pure_python_process_pool_run(synthetic_dataset):
                       spawn_new_process=False)
 
 
+def test_pure_python_process_pool_run_with_pyarrow_serialize(synthetic_dataset):
+    reader_throughput(synthetic_dataset.url, ['id'], warmup_cycles_count=5, measure_cycles_count=5,
+                      pool_type=WorkerPoolType.PROCESS, loaders_count=1, read_method=ReadMethod.PYTHON,
+                      spawn_new_process=False, pyarrow_serialize=True)
+
+
 def test_tf_thread_pool_run(synthetic_dataset):
     reader_throughput(synthetic_dataset.url, ['id', 'id2'], warmup_cycles_count=5, measure_cycles_count=5,
                       pool_type=WorkerPoolType.THREAD, loaders_count=1, read_method=ReadMethod.TF)
@@ -61,6 +67,12 @@ def test_tf_thread_pool_run_experimental(synthetic_dataset):
     reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
                          measure_cycles_count=5, pool_type=WorkerPoolType.THREAD, loaders_count=1,
                          read_method=ReadMethod.TF)
+
+
+def test_tf_thread_pool_run_experimental_with_pyarrow_serialize(synthetic_dataset):
+    reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
+                         measure_cycles_count=5, pool_type=WorkerPoolType.PROCESS, loaders_count=1,
+                         read_method=ReadMethod.TF, pyarrow_serialize=True)
 
 
 def test_run_benchmark_cycle_length_of_warmup_and_measure_cycles():

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -55,7 +55,7 @@ def _randomize_row(id_num):
         TestSchema.partition_key.name: 'p_{}'.format(int(id_num / 10)),
         TestSchema.python_primitive_uint8.name: np.random.randint(0, 255),
         TestSchema.image_png.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.uint8),
-        TestSchema.matrix.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.float32),
+        TestSchema.matrix.name: np.random.random(size=_DEFAULT_IMAGE_SIZE).astype(np.float32),
         TestSchema.decimal.name: Decimal(np.random.randint(0, 255) / Decimal(100)),
         TestSchema.matrix_uint16.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.uint16),
         TestSchema.matrix_string.name: np.random.randint(0, 100, (4,)).astype(np.string_),

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -72,14 +72,11 @@ def test_simple_read(synthetic_dataset, reader_factory):
         _check_simple_reader(reader, synthetic_dataset.data)
 
 
-@pytest.mark.parametrize('reader_factory',
-                         [
-                             lambda url, **kwargs: Reader(url, reader_pool=ProcessPool(1, pyarrow_serialize=True)),
-                             lambda url, **kwargs: ReaderV2(url, pyarrow_serialize=True,
-                                                            decoder_pool=SameThreadExecutor()),
-                             lambda url, **kwargs: ReaderV2(url, pyarrow_serialize=True,
-                                                            decoder_pool=ProcessPoolExecutor(1)),
-                         ])
+@pytest.mark.parametrize('reader_factory', [
+    lambda url, **kwargs: Reader(url, reader_pool=ProcessPool(1, pyarrow_serialize=True)),
+    lambda url, **kwargs: ReaderV2(url, pyarrow_serialize=True, decoder_pool=SameThreadExecutor()),
+    lambda url, **kwargs: ReaderV2(url, pyarrow_serialize=True, decoder_pool=ProcessPoolExecutor(1)),
+])
 def test_read_with_pyarrow_serialization(synthetic_dataset, reader_factory):
     with reader_factory(synthetic_dataset.url) as reader:
         for actual in reader:

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -53,10 +53,16 @@ ALL_READER_FLAVOR_FACTORIES = MINIMAL_READER_FLAVOR_FACTORIES + [
 
 def _check_simple_reader(reader, expected_data):
     # Read a bunch of entries from the dataset and compare the data to reference
+    def _type(v):
+        return v.dtype if isinstance(v, np.ndarray) else type(v)
+
     for row in reader:
         actual = row._asdict()
         expected = next(d for d in expected_data if d['id'] == actual['id'])
         np.testing.assert_equal(actual, expected)
+        actual_types = [_type(v) for v in actual.values()]
+        expected_types = [_type(v) for v in actual.values()]
+        assert actual_types == expected_types
 
 
 @pytest.mark.parametrize('reader_factory', ALL_READER_FLAVOR_FACTORIES)

--- a/petastorm/tests/test_pyarrow_serializer.py
+++ b/petastorm/tests/test_pyarrow_serializer.py
@@ -1,0 +1,35 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+
+import numpy as np
+
+from petastorm.reader_impl.pyarrow_serializer import PyArrowSerializer
+
+
+def test_nominal():
+    s = PyArrowSerializer()
+    # We would be using serializer with arrays of dictionaries or arrays of dictionaries of dictionaries (ngram)
+    expected = [{'a': np.asarray([1, 2], dtype=np.uint64)}]
+    actual = s.deserialize(s.serialize(expected))
+    np.testing.assert_array_equal(actual[0]['a'], expected[0]['a'])
+
+
+def test_decimal():
+    s = PyArrowSerializer()
+    # We would be using serializer with arrays of dictionaries or arrays of dictionaries of dictionaries (ngram)
+    expected = [{'a': Decimal('1.2')}]
+    actual = s.deserialize(s.serialize(expected))
+    np.testing.assert_array_equal(actual[0]['a'], str(expected[0]['a']))

--- a/petastorm/tests/test_reader_v2.py
+++ b/petastorm/tests/test_reader_v2.py
@@ -1,0 +1,36 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+from time import sleep
+
+from petastorm.reader import ReaderV2
+
+
+def test_bound_size_of_output_queue_size_reader_v2(synthetic_dataset):
+    """Limit the output queue size to 5. Make sure the reader does not overrun the target output queue size.
+    This test is timing sensitive so it might become flaky"""
+    TIME_TO_GET_TO_OUTPUT_QUEUE_OF_5 = 3.0
+    DELTA_T = 0.1
+
+    with ReaderV2(synthetic_dataset.url, target_output_queue_size=5) as reader:
+        next(reader)
+        for _ in range(int(round(TIME_TO_GET_TO_OUTPUT_QUEUE_OF_5 / DELTA_T))):
+            if reader.diagnostics['output_queue_size'] == 5:
+                sleep(1.0)
+                assert reader.diagnostics['output_queue_size'] == 5
+                return
+            sleep(DELTA_T)
+    assert False, 'Was not able to get to 5 items in the output queue withing '

--- a/petastorm/tests/test_row_group_decoder.py
+++ b/petastorm/tests/test_row_group_decoder.py
@@ -38,14 +38,15 @@ def _rand_row(some_number=np.random.randint(0, 255)):
 
 
 def test_row_decoding():
-    expected_row = _rand_row()
-    encoded_row = dict_to_spark_row(TestSchema, expected_row).asDict()
+    rows_to_process = 3
+    expected_rows = [_rand_row() for _ in range(rows_to_process)]
+    encoded_rows = [dict_to_spark_row(TestSchema, expected_row).asDict() for expected_row in expected_rows]
 
     decoder = RowDecoder(TestSchema, None)
-    actual_row = decoder.decode(encoded_row)._asdict()
+    actual_rows = decoder.decode(encoded_rows)
 
-    # Out-of-the-box pytest `assert actual_row == expected_row` can not compare dictionaries properly
-    np.testing.assert_equal(actual_row, expected_row)
+    # Out-of-the-box pytest `assert actual_rows == expected_row` can not compare dictionaries properly
+    np.testing.assert_equal(actual_rows, expected_rows)
 
 
 def test_ngram_decoding():
@@ -63,7 +64,7 @@ def test_ngram_decoding():
     decoder = RowDecoder(TestSchema, ngram_spec)
 
     # decoded_ngrams is a list of 3 dictionaries, each have -1, 0, 1 keys.
-    decoded_ngrams = [decoder.decode(encoded) for encoded in encoded_ngrams]
+    decoded_ngrams = [decoder.decode([encoded])[0] for encoded in encoded_ngrams]
 
     # Verify we got 3 dictionaries
     assert 3 == len(decoded_ngrams)
@@ -75,10 +76,10 @@ def test_ngram_decoding():
     #    0: some_number
     #    1: some_number, some_matrix
     assert 2 == len(single_sample[-1])
-    assert 0 == single_sample[-1].some_number
+    assert 0 == single_sample[-1]['some_number']
 
     assert 1 == len(single_sample[0])
-    assert 1 == single_sample[0].some_number
+    assert 1 == single_sample[0]['some_number']
 
     assert 2 == len(single_sample[1])
-    assert 2 == single_sample[1].some_number
+    assert 2 == single_sample[1]['some_number']

--- a/petastorm/tests/test_same_thread_executor.py
+++ b/petastorm/tests/test_same_thread_executor.py
@@ -31,3 +31,7 @@ def test_many_future_submit():
     completed = as_completed(futures)
     results = [f.result() for f in completed]
     assert list(range(10)) == sorted(results)
+
+
+def test_max_workers():
+    assert SameThreadExecutor()._max_workers == 1

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -57,7 +57,7 @@ def _sanitize_field_tf_types(sample):
       - Decimal to string
       - uint16 to int32
 
-    :param sample: named tuple or a dictoinary
+    :param sample: named tuple or a dictionary
     :return: same type as the input with values casted to types supported by Tensorflow
     """
     next_sample_dict = sample._asdict()


### PR DESCRIPTION
This is an optimization that helps in case of a small row sizes and decoders running in a process pool.
When bundled, a decoder returns multiple rows in a single queued message and we potentially save tens of thousands of small message passed cross process boundaries.

