### PR TITLE
Add ability to bundle unischema fields for storage

### DIFF
--- a/petastorm/etl/__init__.py
+++ b/petastorm/etl/__init__.py
@@ -32,7 +32,7 @@ class RowGroupIndexerBase(object):
 
     @abc.abstractproperty
     def column_names(self):
-        """ Return list of column(s) reuired to build index."""
+        """ Return list of fields required to build index. This refers to unischema field names"""
         return None
 
     @abc.abstractproperty

--- a/petastorm/reader_impl/row_bundler.py
+++ b/petastorm/reader_impl/row_bundler.py
@@ -1,0 +1,110 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from io import BytesIO
+
+import numpy as np
+
+
+class RowStorageBundler(object):
+    def __init__(self, schema):
+        """RowStorageBundler handles bundling a row's fields into a smaller number columns for storage.
+        This is used to prevent wasting a round trip to remote storage to read a very small amount of data
+        which is specifically a problem with Parquet if your rows are a mix of very large and very small
+        columns. Your row group size is determined by the large columns, meaning the small column will contain
+        very little data in a single row group.
+
+        :param schema: A Unischema instance
+        """
+        self._schema = schema
+
+    def bundle_row(self, row):
+        """
+        Takes a dictionary of encoded fields and bundles them into columns for storage. It encodes the
+        bundles as a numpy array.
+
+        Example:
+
+        Input:
+          row = {
+            'rgb-image': bytearray(),
+            'image-id': 'my-image-id',
+            'height-px': 240,
+            'width-px': 240,
+            ...
+          }
+
+        Output:
+          row = {
+            'image-bundle': bytearray(),
+            ...
+          }
+
+
+        :param row:
+        :return: a dictionary of the bundled fields
+        """
+        bundled_dict = {}
+        included_field_names = set()
+        for bundle_name, bundle_columns in self._schema.column_bundles.items():
+            bundle_vals = [row[field_name] for field_name in bundle_columns]
+            numpy_array = np.array(bundle_vals, dtype=object)
+            memfile = BytesIO()
+            np.save(memfile, numpy_array)
+            bundled_dict[bundle_name] = bytearray(memfile.getvalue())
+            memfile.close()
+            # Keep track of included fields to add any columns not included in a bundle individually
+            included_field_names.update(bundle_columns)
+        for field_name in row:
+            if field_name not in included_field_names:
+                bundled_dict[field_name] = row[field_name]
+        return bundled_dict
+
+    def debundle_row(self, row):
+        """
+        Converts a row with bundled columns to a row with all fields flattened properly.
+        All fields in the returned dictionary are still individually encoded.
+
+        Example:
+
+        Input:
+          row = {
+            'image-bundle': bytearray(),
+            ...
+          }
+
+        Output:
+          row = {
+            'rgb-image': bytearray(),
+            'image-id': 'my-image-id',
+            'height-px': 240,
+            'width-px': 240,
+            ...
+          }
+
+        :param row: A dictionary of columns, some of which are potentially bundled
+        :return: A dictionary of encoded unischema fields
+        """
+        unbundled_row = dict()
+        for column_name_unicode, column_value in row.items():
+            column_name = str(column_name_unicode)
+            if column_name in self._schema.column_bundles:
+                memfile = BytesIO(column_value)
+                decoded_bundle = np.load(memfile)
+                memfile.close()
+                bundled_fields = self._schema.column_bundles[column_name]
+                for i, field in enumerate(bundled_fields):
+                    unbundled_row[field] = decoded_bundle[i]
+            else:
+                unbundled_row[column_name] = column_value
+        return unbundled_row

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -44,7 +44,7 @@ TestSchema = Unischema('TestSchema', [
     UnischemaField('matrix_nullable', np.uint16, _DEFAULT_IMAGE_SIZE, NdarrayCodec(), True),
     UnischemaField('sensor_name', np.unicode_, (1,), NdarrayCodec(), False),
     UnischemaField('string_array_nullable', np.unicode_, (None,), NdarrayCodec(), True),
-])
+], column_bundles={'images': ['id2', 'image_png'], 'sensor': ['id2', 'sensor_name']})
 
 
 def _randomize_row(id_num):

--- a/petastorm/utils.py
+++ b/petastorm/utils.py
@@ -14,11 +14,9 @@
 
 import logging
 import os
-
-import pyarrow
-
 from multiprocessing import Pool
 
+import pyarrow
 from pyarrow.filesystem import LocalFileSystem
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I still need to add some more tests and improve documentation but it should be open for feedback.

Note one design choice I have included is that a field can be in multiple bundles, meaning you can include a small field multiple times in a row stored in different columns. This can be useful if you commonly need the same small piece of metadata with 2 large fields which can be read separately.

I know we had discussions on predicates on decoded data but I will do that in a separate PR since that change is unrelated to bundling.