### PR TITLE
ProcessPool output queue size control and zero copy pyarrow serialization

### DIFF
--- a/petastorm/benchmark/cli.py
+++ b/petastorm/benchmark/cli.py
@@ -75,6 +75,11 @@ def _parse_args(args):
     parser.add_argument('--experimental-decoders-count', type=int, default=3, required=False,
                         help='Number of decoder threads/processes. Used only if --experimental-reader is set.')
 
+    parser.add_argument('--pyarrow-serialize', action='store_true', required=False,
+                        help='When specified, faster pyarrow.serialize library is used. However, it does not support '
+                             'all data types and implicitly converts some datatypes (e.g. int64->int32) which may'
+                             'trigger errors when reading the data from Tensorflow.')
+
     parser.add_argument('-vv', action='store_true', default=False, help='Sets logging level to DEBUG.')
     parser.add_argument('-v', action='store_true', default=False, help='Sets logging level to INFO.')
 
@@ -101,14 +106,15 @@ def _main(args):
                                        loaders_count=args.workers_count,
                                        decoders_count=args.experimental_decoders_count, read_method=args.read_method,
                                        shuffling_queue_size=args.shuffling_queue_size,
-                                       min_after_dequeue=args.min_after_dequeue)
+                                       min_after_dequeue=args.min_after_dequeue,
+                                       pyarrow_serialize=args.pyarrow_serialize)
 
     else:
         results = reader_throughput(args.dataset_path, args.field_regex, warmup_cycles_count=args.warmup_cycles,
                                     measure_cycles_count=args.measure_cycles, pool_type=args.pool_type,
                                     loaders_count=args.workers_count, profile_threads=args.profile_threads,
                                     read_method=args.read_method, shuffling_queue_size=args.shuffling_queue_size,
-                                    min_after_dequeue=args.min_after_dequeue)
+                                    min_after_dequeue=args.min_after_dequeue, pyarrow_serialize=args.pyarrow_serialize)
 
     logger.info('Done')
     print('Average sample read rate: {:1.2f} samples/sec; RAM {:1.2f} MB (rss); '

--- a/petastorm/benchmark/throughput.py
+++ b/petastorm/benchmark/throughput.py
@@ -114,7 +114,7 @@ def _time_warmup_and_work_tf(reader, warmup_cycles_count, measure_cycles_count, 
 def reader_throughput(dataset_url, field_regex=None, warmup_cycles_count=300, measure_cycles_count=1000,
                       pool_type=WorkerPoolType.THREAD, loaders_count=3, profile_threads=False,
                       read_method=ReadMethod.PYTHON, shuffling_queue_size=500, min_after_dequeue=400,
-                      reader_extra_args=None, spawn_new_process=True):
+                      reader_extra_args=None, pyarrow_serialize=False, spawn_new_process=True):
     """Constructs a Reader instance and uses it to performs throughput measurements.
 
     The function will spawn a new process if ``spawn_separate_process`` is set. This is needed to make memory footprint
@@ -134,6 +134,7 @@ def reader_throughput(dataset_url, field_regex=None, warmup_cycles_count=300, me
     :param shuffling_queue_size: Maximum number of elements in the shuffling queue.
     :param min_after_dequeue: Minimum number of elements in a shuffling queue before entries can be read from it.
     :param reader_extra_args: Extra arguments that would be passed to Reader constructor.
+    :param pyarrow_serialize: When True, pyarrow.serialize library will be used for serializing decoded payloads.
     :param spawn_new_process: This function will respawn itself in a new process if the argument is True. Spawning
       a new process is needed to get an accurate memory footprint.
 
@@ -160,7 +161,7 @@ def reader_throughput(dataset_url, field_regex=None, warmup_cycles_count=300, me
 
     with Reader(dataset_url,
                 num_epochs=None,
-                reader_pool=_create_worker_pool(pool_type, loaders_count, profile_threads),
+                reader_pool=_create_worker_pool(pool_type, loaders_count, profile_threads, pyarrow_serialize),
                 **reader_extra_args) as reader:
 
         if read_method == ReadMethod.PYTHON:
@@ -177,7 +178,7 @@ def reader_throughput(dataset_url, field_regex=None, warmup_cycles_count=300, me
 def reader_v2_throughput(dataset_url, field_regex=None, warmup_cycles_count=300, measure_cycles_count=1000,
                          pool_type=WorkerPoolType.THREAD, loaders_count=3, decoders_count=3,
                          read_method=ReadMethod.PYTHON, shuffling_queue_size=500, min_after_dequeue=400,
-                         reader_extra_args=None, spawn_new_process=True):
+                         reader_extra_args=None, pyarrow_serialize=False, spawn_new_process=True):
     """Constructs a ReaderV2 instance and uses it to performs throughput measurements.
 
     The function will spawn a new process if ``spawn_separate_process`` is set. This is needed to make memory footprint
@@ -198,6 +199,7 @@ def reader_v2_throughput(dataset_url, field_regex=None, warmup_cycles_count=300,
     :param shuffling_queue_size: Maximum number of elements in the shuffling queue.
     :param min_after_dequeue: Minimum number of elements in a shuffling queue before entries can be read from it.
     :param reader_extra_args: Extra arguments that would be passed to Reader constructor.
+    :param pyarrow_serialize: When True, pyarrow.serialize library will be used for serializing decoded payloads.
     :param spawn_new_process: This function will respawn itself in a new process if the argument is True. Spawning
       a new process is needed to get an accurate memory footprint.
 
@@ -252,12 +254,12 @@ def _create_concurrent_executor(pool_type, decoders_count):
     return decoder_pool_executor
 
 
-def _create_worker_pool(pool_type, workers_count, profiling_enabled):
+def _create_worker_pool(pool_type, workers_count, profiling_enabled, pyarrow_serialize):
     """Different worker pool implementation (in process none or thread-pool, out of process pool)"""
     if pool_type == WorkerPoolType.THREAD:
         worker_pool = ThreadPool(workers_count, profiling_enabled=profiling_enabled)
     elif pool_type == WorkerPoolType.PROCESS:
-        worker_pool = ProcessPool(workers_count)
+        worker_pool = ProcessPool(workers_count, pyarrow_serialize=pyarrow_serialize)
     elif pool_type == WorkerPoolType.NONE:
         worker_pool = DummyPool()
     else:

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -315,12 +315,7 @@ class Reader(object):
 
     @property
     def diagnostics(self):
-        diags = {}
-        if hasattr(self._workers_pool, 'results_qsize'):
-            diags['output_queue_size'] = self._workers_pool.results_qsize()
-        else:
-            diags['output_queue_size'] = None
-        return diags
+        return self._workers_pool.diagnostics
 
     def __iter__(self):
         return self

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -166,6 +166,8 @@ class Reader(object):
         self._workers_pool.start(ReaderWorker,
                                  (dataset_url, self.schema, self.ngram, row_groups, cache, filesystem),
                                  ventilator=ventilator)
+        logger.debug('Workers pool started')
+
         self.last_row_consumed = False
 
         # _result

--- a/petastorm/reader_impl/pickle_serializer.py
+++ b/petastorm/reader_impl/pickle_serializer.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pickle
+
+
+class PickleSerializer(object):
+
+    def serialize(self, rows):
+        return pickle.dumps(rows)
+
+    def deserialize(self, serialized_rows):
+        return pickle.loads(serialized_rows)

--- a/petastorm/tests/test_benchmark.py
+++ b/petastorm/tests/test_benchmark.py
@@ -30,6 +30,12 @@ def test_pure_python_process_pool_run(synthetic_dataset):
                       spawn_new_process=False)
 
 
+def test_pure_python_process_pool_run_with_pyarrow_serialize(synthetic_dataset):
+    reader_throughput(synthetic_dataset.url, ['id'], warmup_cycles_count=5, measure_cycles_count=5,
+                      pool_type=WorkerPoolType.PROCESS, loaders_count=1, read_method=ReadMethod.PYTHON,
+                      spawn_new_process=False, pyarrow_serialize=True)
+
+
 def test_tf_thread_pool_run(synthetic_dataset):
     reader_throughput(synthetic_dataset.url, ['id', 'id2'], warmup_cycles_count=5, measure_cycles_count=5,
                       pool_type=WorkerPoolType.THREAD, loaders_count=1, read_method=ReadMethod.TF)
@@ -61,6 +67,12 @@ def test_tf_thread_pool_run_experimental(synthetic_dataset):
     reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
                          measure_cycles_count=5, pool_type=WorkerPoolType.THREAD, loaders_count=1,
                          read_method=ReadMethod.TF)
+
+
+def test_tf_thread_pool_run_experimental_with_pyarrow_serialize(synthetic_dataset):
+    reader_v2_throughput(synthetic_dataset.url, field_regex=[r'\bid\b', r'\bmatrix\b'], warmup_cycles_count=5,
+                         measure_cycles_count=5, pool_type=WorkerPoolType.PROCESS, loaders_count=1,
+                         read_method=ReadMethod.TF, pyarrow_serialize=True)
 
 
 def test_run_benchmark_cycle_length_of_warmup_and_measure_cycles():

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -79,6 +79,7 @@ def test_simple_read(synthetic_dataset, reader_factory):
                          MINIMAL_READER_FLAVOR_FACTORIES +
                          [lambda url, **kwargs: Reader(url, reader_pool=ThreadPool(10), **kwargs),
                           lambda url, **kwargs: Reader(url, reader_pool=ProcessPool(10), **kwargs)])
+@pytest.mark.forked
 def test_simple_read_with_disk_cache(synthetic_dataset, reader_factory, tmpdir):
     """Try using the Reader with LocalDiskCache using different flavors of pools"""
     CACHE_SIZE = 10 * 2 ** 30  # 20GB

--- a/petastorm/tests/test_pickle_serializer.py
+++ b/petastorm/tests/test_pickle_serializer.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+
+import numpy as np
+
+from petastorm.reader_impl.pickle_serializer import PickleSerializer
+
+
+def _foo():
+    pass
+
+
+def test_nominal():
+    s = PickleSerializer()
+    expected = [{'a': np.asarray([1, 2], dtype=np.uint64), 'b': Decimal(1.2), 'c': _foo}]
+    actual = s.deserialize(s.serialize(expected))
+    np.testing.assert_array_equal(actual[0]['a'], expected[0]['a'])

--- a/petastorm/workers_pool/dummy_pool.py
+++ b/petastorm/workers_pool/dummy_pool.py
@@ -84,3 +84,7 @@ class DummyPool(object):
 
     def join(self):
         pass
+
+    @property
+    def diagnostics(self):
+        return dict()

--- a/petastorm/workers_pool/dummy_pool.py
+++ b/petastorm/workers_pool/dummy_pool.py
@@ -33,6 +33,7 @@ class DummyPool(object):
         self._results_queue = []
         self._worker = None
         self._ventilator = None
+        self.workers_count = 1
 
     def start(self, worker_class, worker_args=None, ventilator=None):
         # Instantiate a single worker with all the args

--- a/petastorm/workers_pool/process_pool.py
+++ b/petastorm/workers_pool/process_pool.py
@@ -98,7 +98,7 @@ class ProcessPool(object):
         self._workers = []
         self._ventilator_send = None
         self._control_sender = None
-        self._workers_count = workers_count
+        self.workers_count = workers_count
         self._results_receiver_poller = None
 
         self._ventilated_items = 0
@@ -167,7 +167,7 @@ class ProcessPool(object):
         self._workers = [
             exec_in_new_process(_worker_bootstrap, worker_class, worker_id, control_socket, worker_receiver_socket,
                                 results_sender_socket, self._serializer, worker_setup_args)
-            for worker_id in range(self._workers_count)]
+            for worker_id in range(self.workers_count)]
 
         # Block until we have all workers up. Will raise an error if fails to start in a timely fashion
         self._wait_for_workers_to_start(monitor_sockets)
@@ -181,13 +181,13 @@ class ProcessPool(object):
         now = time()
         for monitor_socket in monitor_sockets:
             started_count = 0
-            while started_count < self._workers_count and time() < now + _WORKERS_STARTED_TIMEOUT_S:
+            while started_count < self.workers_count and time() < now + _WORKERS_STARTED_TIMEOUT_S:
                 _keep_retrying_while_zmq_again(_KEEP_TRYING_WHILE_ZMQ_AGAIN_IS_RAIZED_TIMEOUT_S,
                                                lambda sock=monitor_socket: monitor.recv_monitor_message(
                                                    sock, flags=zmq.constants.NOBLOCK))
                 started_count += 1
 
-            if started_count < self._workers_count:
+            if started_count < self.workers_count:
                 raise RuntimeError(
                     'Workers were not able to start within timeout {} s ({} has started)'.format(
                         _WORKERS_STARTED_TIMEOUT_S,

--- a/petastorm/workers_pool/process_pool.py
+++ b/petastorm/workers_pool/process_pool.py
@@ -27,8 +27,7 @@ from zmq.utils import monitor
 
 from petastorm.reader_impl.pickle_serializer import PickleSerializer
 from petastorm.reader_impl.pyarrow_serializer import PyArrowSerializer
-from petastorm.workers_pool import EmptyResultError, VentilatedItemProcessedMessage, \
-    TimeoutWaitingForResultError
+from petastorm.workers_pool import EmptyResultError, VentilatedItemProcessedMessage
 from petastorm.workers_pool.exec_in_new_process import exec_in_new_process
 
 # When _CONTROL_FINISHED is passed via control socket to a worker, the worker will terminate

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -216,3 +216,7 @@ class ThreadPool(object):
 
     def results_qsize(self):
         return self._results_queue.qsize()
+
+    @property
+    def diagnostics(self):
+        return {'output_queue_size': self.results_qsize()}

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -92,7 +92,7 @@ class ThreadPool(object):
         self._seed = random.randint(0, 100000)
         self._workers = []
         self._ventilator_queue = None
-        self._workers_count = workers_count
+        self.workers_count = workers_count
         self._results_queue_size = results_queue_size
         # Worker threads will watch this event and gracefully shutdown when the event is set
         self._stop_event = Event()
@@ -120,7 +120,7 @@ class ThreadPool(object):
         self._ventilator_queue = queue.Queue()
         self._results_queue = queue.Queue(self._results_queue_size)
         self._workers = []
-        for worker_id in range(self._workers_count):
+        for worker_id in range(self.workers_count):
             worker_impl = worker_class(worker_id, self._stop_aware_put, worker_args)
             new_thread = WorkerThread(worker_impl, self._stop_event, self._ventilator_queue,
                                       self._results_queue, self._profiling_enabled)


### PR DESCRIPTION
Effective control over the amount of rowgroups that are processed by process pool. The size of rowgroups allowed to be somewhere in loading/decoding is defined now by the amount of workers.

Improved the way we use pyarrow serialization and pyzmq to reduce amount of memory copies.

Improved pyarrow serialization to support decimal.Decimal type.

Improved diagnostics reported by Reader.

These are too many changes for a single PR, but they are split into small commits.