### PR TITLE
Removing non-ascii character for README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,7 +271,7 @@ run tests.
 Publications
 ------------
 
-1. Gruener, R., Cheng, O., and Litvin, Y. (2018) *Introducing Petastorm: Uber ATG’s Data Access Library for Deep Learning*. URL: https://eng.uber.com/petastorm/
+1. Gruener, R., Cheng, O., and Litvin, Y. (2018) *Introducing Petastorm: Uber ATG's Data Access Library for Deep Learning*. URL: https://eng.uber.com/petastorm/
 
 
 .. _Troubleshooting: docs/troubleshoot.rst


### PR DESCRIPTION
Non ascii character in README.rst results in a failure of `pip install -e .` on machines
without configured locale. This happens, for example, in a fresh ubuntu docker image.