### PR TITLE
Fix running tests locally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # pyarrow was compiled against a newer version of numpy than we require so we need to upgrade it
   # (or optionally install pyarrow from source instead of through binaries)
   - pip install --upgrade numpy
-  - pip install pytest-timeout pytest-logger
+  - pip install pytest-timeout
 
 before_script:
   # enable core dumps

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ EXTRA_REQUIRE = {
         'pytest>=3.0.0',
         'pytest-cov>=2.5.1',
         'pytest-forked>=0.2',
+        'pytest-logger>=0.4.0',
     ],
     'torch': ['torchvision>=0.2.1'],
 }


### PR DESCRIPTION
Move installation of pytest-logger into setup.py. Apparently all hooks in conftest.py need to be known to pytest, otherwise the tests fail.