### PR TITLE
Make petastorm.pytorch.Dataloader compatible with additional integer types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,17 +62,24 @@ script:
   # waste time on recreating them
 
   # Tensorflow and pytorch tests confict (segfault). Split into separate runs.
-  - pytest --timeout=180 --duration=0 -v examples/mnist/tests/test_pytorch_mnist.py --cov=./ --cov-append
+  - pytest --timeout=180 --duration=0 -v
+    --cov=./ --cov-append
+    examples/mnist/tests/test_pytorch_mnist.py
+    petastorm/tests/test_pytorch_dataloader.py
 
   # Ignore two pytorch tests to prevent static-TLS-caused torch-import seg-fault
   - pytest --timeout=180 --duration=0 -Y --cache-clear -m "not forked" -v --cov=./  --cov-append --trace-config
     --ignore=examples/mnist/tests/test_pytorch_mnist.py
-    --ignore=petastorm/tests/test_pytorch_utils.py petastorm examples
+    --ignore=petastorm/tests/test_pytorch_utils.py
+    --ignore=petastorm/tests/test_pytorch_dataloader.py
+    petastorm examples
 
   # We have a separate run for forked: make sure fixtures are reused as much as possible
   - pytest --timeout=180 --duration=0 -Y -m "forked" --forked -v --cov=./ --cov-append --trace-config
     --ignore=examples/mnist/tests/test_pytorch_mnist.py
-    --ignore=petastorm/tests/test_pytorch_utils.py petastorm examples
+    --ignore=petastorm/tests/test_pytorch_utils.py
+    --ignore=petastorm/tests/test_pytorch_dataloader.py
+    petastorm examples
 
 after_success:
   - codecov

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -15,7 +15,65 @@
 # Must import pyarrow before torch. See: https://github.com/uber/petastorm/blob/master/docs/troubleshoot.rst
 import pyarrow  # noqa: F401 pylint: disable=W0611
 
+import collections
+import decimal
+
+import numpy as np
+from six import PY2
 from torch.utils.data.dataloader import default_collate
+
+if PY2:
+    _string_classes = basestring  # noqa: F821
+else:
+    _string_classes = (str, bytes)
+
+
+def _sanitize_pytorch_types(row_as_dict):
+    """Promotes values types in a dictionary to the types supported by pytorch. Raises an error if type is clear error
+    if the type can not be promoted.
+
+    The parameter is modified in-place.
+
+    int8, uint16 are promoted to int32; uint32 -> int64;
+    numpy string_, unicode_, object arrays are not supported.
+
+    :param row_as_dict: a dictinoary of key-value pairs. The values types are promoted to pytorch compatible.
+    :return: None
+    """
+    for name, value in row_as_dict.items():
+        # PyTorch supported types are: double, float, float16, int64, int32, and uint8
+        if isinstance(value, np.ndarray):
+            if value.dtype == np.int8:
+                row_as_dict[name] = value.astype(np.int16)
+            elif value.dtype == np.uint16:
+                row_as_dict[name] = value.astype(np.int32)
+            elif value.dtype == np.uint32:
+                row_as_dict[name] = value.astype(np.int64)
+
+
+def decimal_friendly_collate(batch):
+    """A wrapper on top of ``default_collate`` function that allows decimal.Decimal types to be collated.
+
+    We use ``decimal.Decimal`` types in petastorm dataset to represent timestamps. PyTorch's ``default_collate``
+    implementation does not support collating ``decimal.Decimal`` types. ``decimal_friendly_collate`` collates
+    ``decimal.Decima al`` separately and then combines with the rest of the fields collated by a standard
+    ``default_collate``.
+
+    :param batch: A list of dictionaries to collate
+    :return: A dictionary of lists/pytorch.Tensor types
+    """
+
+    if isinstance(batch[0], decimal.Decimal):
+        return batch
+    elif isinstance(batch[0], collections.Mapping):
+        return {key: decimal_friendly_collate([d[key] for d in batch]) for key in batch[0]}
+    elif isinstance(batch[0], _string_classes):
+        return batch
+    elif isinstance(batch[0], collections.Sequence):
+        transposed = zip(*batch)
+        return [decimal_friendly_collate(samples) for samples in transposed]
+    else:
+        return default_collate(batch)
 
 
 class DataLoader(object):
@@ -31,7 +89,7 @@ class DataLoader(object):
     once more at the very end.
     """
 
-    def __init__(self, reader, batch_size=1, collate_fn=default_collate, transform=None):
+    def __init__(self, reader, batch_size=1, collate_fn=decimal_friendly_collate, transform=None):
         """
         Initializes a data loader object, with a default collate and optional transform functions.
 
@@ -58,7 +116,9 @@ class DataLoader(object):
             # Default collate does not work nicely on namedtuples and treat them as lists
             # Using dict will result in the yielded structures being dicts as well
             row_as_dict = row._asdict()
-            batch.append(self.transform(row_as_dict) if self.transform else row_as_dict)
+            _sanitize_pytorch_types(row_as_dict)
+            transformed_row = self.transform(row_as_dict) if self.transform else row_as_dict
+            batch.append(transformed_row)
             if len(batch) == self.batch_size:
                 yield self.collate_fn(batch)
                 batch = []

--- a/petastorm/tests/test_pytorch_dataloader.py
+++ b/petastorm/tests/test_pytorch_dataloader.py
@@ -1,0 +1,133 @@
+from concurrent.futures import ProcessPoolExecutor
+from decimal import Decimal
+
+import numpy as np
+import pytest
+# Must import pyarrow before torch. See: https://github.com/uber/petastorm/blob/master/docs/troubleshoot.rst
+import pyarrow  # noqa: F401 pylint: disable=W0611
+import torch
+
+from petastorm import make_reader
+from petastorm.pytorch import _sanitize_pytorch_types, DataLoader, decimal_friendly_collate
+from petastorm.reader import ReaderV2
+from petastorm.tests.test_common import TestSchema
+
+BATCHABLE_FIELDS = set(TestSchema.fields.values()) - \
+                   {TestSchema.matrix_nullable, TestSchema.string_array_nullable,
+                    TestSchema.matrix_string, TestSchema.empty_matrix_string}
+
+# pylint: disable=unnecessary-lambda
+MINIMAL_READER_FLAVOR_FACTORIES = [
+    lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
+    lambda url, **kwargs: ReaderV2(url, **kwargs)
+]
+
+# pylint: disable=unnecessary-lambda
+ALL_READER_FLAVOR_FACTORIES = MINIMAL_READER_FLAVOR_FACTORIES + [
+    lambda url, **kwargs: make_reader(url, reader_pool_type='thread', **kwargs),
+    lambda url, **kwargs: make_reader(url, reader_pool_type='process', pyarrow_serialize=False, **kwargs),
+    lambda url, **kwargs: make_reader(url, reader_pool_type='process', workers_count=1,
+                                      pyarrow_serialize=True, **kwargs),
+    lambda url, **kwargs: ReaderV2(url, decoder_pool=ProcessPoolExecutor(10), **kwargs)
+]
+
+
+def _check_simple_reader(loader, expected_data, expected_fields):
+    # Read a bunch of entries from the dataset and compare the data to reference
+    def _type(v):
+        return v.dtype if isinstance(v, np.ndarray) else type(v)
+
+    def _unbatch(x):
+        if isinstance(x, torch.Tensor):
+            x_numpy = x.numpy()
+            assert x_numpy.shape[0] == 1
+            return x_numpy.squeeze(0)
+        elif isinstance(x, list):
+            return x[0]
+        else:
+            raise RuntimeError('Unexpected type while unbatching.')
+
+    expected_field_names = [f.name for f in expected_fields]
+    for actual in loader:
+        actual_numpy = {k: _unbatch(v) for k, v in actual.items() if k in expected_field_names}
+        expected_all_fields = next(d for d in expected_data if d['id'] == actual_numpy['id'])
+        expected = {k: v for k, v in expected_all_fields.items() if k in expected_field_names}
+        np.testing.assert_equal(actual_numpy, expected)
+        actual_types = [_type(v) for v in actual_numpy.values()]
+        expected_types = [_type(v) for v in actual_numpy.values()]
+        assert actual_types == expected_types
+
+
+def _sensor_name_to_int(row):
+    result_row = dict(**row)
+    result_row['sensor_name'] = 0
+    return result_row
+
+
+@pytest.mark.parametrize('reader_factory', ALL_READER_FLAVOR_FACTORIES)
+def test_simple_read(synthetic_dataset, reader_factory):
+    with DataLoader(reader_factory(synthetic_dataset.url, schema_fields=BATCHABLE_FIELDS),
+                    transform=_sensor_name_to_int) as loader:
+        _check_simple_reader(loader, synthetic_dataset.data, BATCHABLE_FIELDS - {TestSchema.sensor_name})
+
+
+def test_sanitize_pytorch_types_int8():
+    dict_to_sanitize = {'a': np.asarray([-1, 1], dtype=np.int8)}
+    _sanitize_pytorch_types(dict_to_sanitize)
+    np.testing.assert_array_equal(dict_to_sanitize['a'], [-1, 1])
+    assert dict_to_sanitize['a'].dtype == np.int16
+
+
+def test_decimal_friendly_collate_empty_input():
+    assert decimal_friendly_collate([dict()]) == dict()
+
+
+@pytest.mark.parametrize('numpy_dtype',
+                         [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64])
+def test_torch_tensorable_types(numpy_dtype):
+    """Make sure that we 'sanitize' only integer types that can not be made into torch tensors natively"""
+    value = np.zeros((2, 2), dtype=numpy_dtype)
+    dict_to_sanitize = {'value': value}
+    _sanitize_pytorch_types(dict_to_sanitize)
+
+    torchable = False
+    try:
+        torch.Tensor(value)
+        torchable = True
+    except TypeError:
+        pass
+
+    tensor = torch.as_tensor(dict_to_sanitize['value'])
+
+    tensor_and_back = tensor.numpy()
+
+    if tensor_and_back.dtype != value.dtype:
+        assert tensor_and_back.dtype.itemsize > value.dtype.itemsize
+        assert not torchable, '_sanitize_pytorch_types modified value of type {}, but it was possible to create a ' \
+                              'Tensor directly from a value with that type'.format(numpy_dtype)
+
+
+def test_decimal_friendly_collate_input_has_decimals_in_dictionary():
+    desired = {
+        'decimal': [Decimal('1.0'), Decimal('1.1')],
+        'int': [1, 2]
+    }
+    input_batch = [
+        {'decimal': Decimal('1.0'), 'int': 1},
+        {'decimal': Decimal('1.1'), 'int': 2},
+    ]
+    actual = decimal_friendly_collate(input_batch)
+
+    assert len(actual) == 2
+    assert desired['decimal'] == actual['decimal']
+    np.testing.assert_equal(desired['int'], actual['int'].numpy())
+
+
+def test_decimal_friendly_collate_input_has_decimals_in_tuple():
+    input_batch = ([Decimal('1.0'), 1], [Decimal('1.1'), 2])
+    desired = [(Decimal('1.0'), Decimal('1.1')), (1, 2)]
+    actual = decimal_friendly_collate(input_batch)
+
+    assert len(actual) == 2
+    assert desired[0] == actual[0]
+    np.testing.assert_equal(desired[1], actual[1].numpy())


### PR DESCRIPTION
PyTorch supports only following integer types: int8, int32 and int64. PyTorch does not
support tensors of strings/objects. Adding an extra stage in `petastorm.pytorch.Dataloader`
that promotes unsupported integer types to the next (wider) integer type that is supported.

Raising an exception with a clear message if a value is unsupported and can not be
promoted, such as `np.string_`, `np.unicode_` or `np.object`.