### PR TITLE
Make test_shuffle_drop_ratio by not setting shuffle_row_drop_partitions >> rowgroup size.

### DIFF
--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -164,7 +164,7 @@ def test_shuffle_drop_ratio(synthetic_dataset, reader_factory):
 
     # Test that the ids are increasingly not consecutive numbers as we increase the shuffle dropout
     prev_jumps_not_1 = 0
-    for shuffle_dropout in [2, 5, 8, 111]:
+    for shuffle_dropout in [2, 5, 8]:
         readout = readout_all_ids(True, shuffle_dropout)
         assert len(first_readout) == len(readout)
         jumps_not_1 = np.sum(np.diff(readout) != 1)


### PR DESCRIPTION
It was working fast while we knew the number of rows in each rowgroup. We don't have this information now,
so there are many row-groups that are dropped without being used by shuffle_row_drop_partition feature.

The time it takes for the test to finish now is 2 seconds instead of 23 seconds (and I assume it takes more on travis)