### PR TITLE
Support reader_engine=experimental_reader_v2 and reader_engine_params parameters in make_reader factory function

### DIFF
--- a/petastorm/tests/test_copy_dataset.py
+++ b/petastorm/tests/test_copy_dataset.py
@@ -21,7 +21,7 @@ import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 
-from petastorm.reader import ReaderV2
+from petastorm.reader import make_reader
 from petastorm.tools.copy_dataset import _main, copy_dataset
 
 
@@ -34,7 +34,7 @@ def test_copy_and_overwrite_cli(tmpdir, synthetic_dataset):
     target_url = 'file:///' + os.path.join(tmpdir.strpath, 'copied_data')
     _main([synthetic_dataset.url, target_url])
 
-    with ReaderV2(target_url, num_epochs=1) as reader:
+    with make_reader(target_url, num_epochs=1) as reader:
         for row in reader:
             actual = row._asdict()
             expected = next(d for d in synthetic_dataset.data if d['id'] == actual['id'])
@@ -55,7 +55,7 @@ def test_copy_some_fields_with_repartition_cli(tmpdir, synthetic_dataset):
     assert 1 == len(glob.glob(os.path.join(target_path, 'part-*')))
 
     # Check we the regex filter worked
-    with ReaderV2(target_url, num_epochs=1) as reader:
+    with make_reader(target_url, num_epochs=1) as reader:
         assert list(reader.schema.fields.keys()) == ['id']
 
 
@@ -63,7 +63,7 @@ def test_copy_not_null_rows_cli(tmpdir, synthetic_dataset):
     target_url = 'file://' + os.path.join(tmpdir.strpath, 'copied_data')
 
     _main([synthetic_dataset.url, target_url, '--not-null-fields', 'string_array_nullable'])
-    with ReaderV2(target_url, num_epochs=1) as reader:
+    with make_reader(target_url, num_epochs=1) as reader:
         not_null_data = list(reader)
     assert len(not_null_data) < len(synthetic_dataset.data)
 

--- a/petastorm/tests/test_ngram_end_to_end.py
+++ b/petastorm/tests/test_ngram_end_to_end.py
@@ -24,7 +24,6 @@ from tensorflow.python.framework.errors_impl import OutOfRangeError
 
 from petastorm import make_reader
 from petastorm.ngram import NGram
-from petastorm.reader import ReaderV2
 from petastorm.reader_impl.same_thread_executor import SameThreadExecutor
 from petastorm.tests.conftest import SyntheticDataset, maybe_cached_dataset
 from petastorm.tests.test_common import create_test_dataset, TestSchema
@@ -35,7 +34,8 @@ from petastorm.tf_utils import tf_tensors
 READER_FACTORIES = [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
     lambda url, **kwargs: make_reader(url, reader_pool_type='process', workers_count=1, **kwargs),
-    lambda url, **kwargs: ReaderV2(url, loader_pool=SameThreadExecutor(), decoder_pool=SameThreadExecutor(), **kwargs),
+    lambda url, **kwargs: make_reader(url, reader_engine='experimental_reader_v2', reader_pool_type='dummy',
+                                      reader_engine_params={'loader_pool': SameThreadExecutor()}, **kwargs),
 ]
 
 

--- a/petastorm/tests/test_pytorch_dataloader.py
+++ b/petastorm/tests/test_pytorch_dataloader.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ProcessPoolExecutor
 from decimal import Decimal
 
 import numpy as np
@@ -9,7 +8,6 @@ import torch
 
 from petastorm import make_reader
 from petastorm.pytorch import _sanitize_pytorch_types, DataLoader, decimal_friendly_collate
-from petastorm.reader import ReaderV2
 from petastorm.tests.test_common import TestSchema
 
 BATCHABLE_FIELDS = set(TestSchema.fields.values()) - \
@@ -19,16 +17,16 @@ BATCHABLE_FIELDS = set(TestSchema.fields.values()) - \
 # pylint: disable=unnecessary-lambda
 MINIMAL_READER_FLAVOR_FACTORIES = [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
-    lambda url, **kwargs: ReaderV2(url, **kwargs)
+    lambda url, **kwargs: make_reader(url, reader_engine='experimental_reader_v2', **kwargs)
 ]
 
 # pylint: disable=unnecessary-lambda
 ALL_READER_FLAVOR_FACTORIES = MINIMAL_READER_FLAVOR_FACTORIES + [
     lambda url, **kwargs: make_reader(url, reader_pool_type='thread', **kwargs),
     lambda url, **kwargs: make_reader(url, reader_pool_type='process', pyarrow_serialize=False, **kwargs),
-    lambda url, **kwargs: make_reader(url, reader_pool_type='process', workers_count=1,
-                                      pyarrow_serialize=True, **kwargs),
-    lambda url, **kwargs: ReaderV2(url, decoder_pool=ProcessPoolExecutor(10), **kwargs)
+    lambda url, **kwargs: make_reader(url, reader_pool_type='process', workers_count=1, pyarrow_serialize=True,
+                                      **kwargs),
+    lambda url, **kwargs: make_reader(url, reader_engine='experimental_reader_v2', reader_pool_type='process', **kwargs)
 ]
 
 

--- a/petastorm/workers_pool/exec_in_new_process.py
+++ b/petastorm/workers_pool/exec_in_new_process.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     # An entry point to the newely executed process.
     # Will unpickle function handle and arguments and call the function.
     try:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig()
         if len(sys.argv) != 2:
             raise RuntimeError('Expected a single command line argument')
         new_process_runnable_file = sys.argv[1]


### PR DESCRIPTION
This allows us to change reader implementation in the future, without modifying user code.