### PR TITLE
Split codec tests into separate modules

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -181,6 +181,10 @@ class ScalarCodec(DataframeColumnCodec):
         self._spark_type = spark_type
 
     def encode(self, unischema_field, value):
+        if unischema_field.shape:
+            raise ValueError('The shape field of unischema_field \'%s\' must be an empty tuple (i.e. \'()\' '
+                             'to indicate a scalar. However, the actual shape is %s',
+                             unischema_field.name, unischema_field.shape)
         if isinstance(self._spark_type, (ByteType, ShortType, IntegerType, LongType)):
             return int(value)
         if isinstance(self._spark_type, (FloatType, DoubleType)):

--- a/petastorm/tests/test_codec_compressed_image.py
+++ b/petastorm/tests/test_codec_compressed_image.py
@@ -12,73 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
-from decimal import Decimal
 
 import numpy as np
 import pytest
 from PIL import Image
-from pyspark.sql.types import StringType, ByteType, ShortType, IntegerType, LongType, DecimalType
 
-from petastorm.codecs import NdarrayCodec, CompressedNdarrayCodec, ScalarCodec, CompressedImageCodec
+from petastorm.codecs import CompressedImageCodec
 from petastorm.unischema import UnischemaField
-
-
-def test_ndarray_codec():
-    SHAPE = (10, 20, 30)
-    expected = np.random.rand(*SHAPE).astype(dtype=np.int32)
-    codec = NdarrayCodec()
-    field = UnischemaField(name='test_name', numpy_dtype=np.int32, shape=SHAPE, codec=NdarrayCodec(),
-                           nullable=False)
-    np.testing.assert_equal(codec.decode(field, codec.encode(field, expected)), expected)
-
-
-def test_compressed_ndarray_codec():
-    SHAPE = (10, 20, 30)
-    expected = np.random.rand(*SHAPE).astype(dtype=np.int32)
-    codec = CompressedNdarrayCodec()
-    field = UnischemaField(name='test_name', numpy_dtype=np.int32, shape=SHAPE, codec=CompressedNdarrayCodec(),
-                           nullable=False)
-    np.testing.assert_equal(codec.decode(field, codec.encode(field, expected)), expected)
-
-
-def test_scalar_codec_string():
-    codec = ScalarCodec(StringType())
-    field = UnischemaField(name='field_string', numpy_dtype=np.string_, shape=(), codec=codec, nullable=False)
-
-    assert codec.decode(field, codec.encode(field, 'abc')) == b'abc'
-    assert codec.decode(field, codec.encode(field, '')) == b''
-
-
-def test_scalar_codec_unicode():
-    codec = ScalarCodec(StringType())
-    field = UnischemaField(name='field_string', numpy_dtype=np.unicode_, shape=(), codec=codec, nullable=False)
-
-    assert codec.decode(field, codec.encode(field, 'abc')) == 'abc'
-    assert codec.decode(field, codec.encode(field, '')) == ''
-
-
-def _test_scalar_type(spark_type, numpy_type, bits):
-    codec = ScalarCodec(spark_type())
-    field = UnischemaField(name='field_int', numpy_dtype=numpy_type, shape=(), codec=codec, nullable=False)
-
-    min_val, max_val = -2 ** (bits - 1), 2 ** (bits - 1) - 1
-    assert codec.decode(field, codec.encode(field, numpy_type(min_val))) == min_val
-    assert codec.decode(field, codec.encode(field, numpy_type(max_val))) == max_val
-
-
-def test_scalar_codec_byte():
-    _test_scalar_type(ByteType, np.int8, 8)
-    _test_scalar_type(ShortType, np.int16, 16)
-    _test_scalar_type(IntegerType, np.int32, 32)
-    _test_scalar_type(LongType, np.int64, 64)
-
-
-def test_scalar_codec_decimal():
-    codec = ScalarCodec(DecimalType(4, 3))
-    field = UnischemaField(name='field_decimal', numpy_dtype=Decimal, shape=(), codec=codec, nullable=False)
-
-    value = Decimal('123.4567')
-    assert codec.decode(field, codec.encode(field, value)) == value
 
 
 def test_png():

--- a/petastorm/tests/test_codec_ndarray.py
+++ b/petastorm/tests/test_codec_ndarray.py
@@ -1,0 +1,37 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from petastorm.codecs import NdarrayCodec, CompressedNdarrayCodec
+from petastorm.unischema import UnischemaField
+
+NUMERIC_DTYPES = [np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64, np.float32,
+                  np.float64]
+
+
+@pytest.mark.parametrize('codec_factory', [
+    NdarrayCodec,
+    CompressedNdarrayCodec,
+])
+def test_ndarray_codec(codec_factory):
+    SHAPE = (10, 20, 3)
+    for dtype in NUMERIC_DTYPES:
+        expected = np.random.rand(*SHAPE).astype(dtype=dtype)
+        codec = codec_factory()
+        field = UnischemaField(name='test_name', numpy_dtype=dtype, shape=SHAPE, codec=codec, nullable=False)
+        actual = codec.decode(field, codec.encode(field, expected))
+        np.testing.assert_equal(actual, expected)
+        assert expected.dtype == actual.dtype

--- a/petastorm/tests/test_codec_scalar.py
+++ b/petastorm/tests/test_codec_scalar.py
@@ -1,0 +1,78 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from decimal import Decimal
+
+import numpy as np
+import pytest
+from pyspark.sql.types import StringType, ByteType, ShortType, IntegerType, LongType, DecimalType
+
+from petastorm.codecs import ScalarCodec
+from petastorm.unischema import UnischemaField
+
+
+def test_byte_string():
+    codec = ScalarCodec(StringType())
+    field = UnischemaField(name='field_string', numpy_dtype=np.string_, shape=(), codec=codec, nullable=False)
+
+    assert codec.decode(field, codec.encode(field, 'abc')) == b'abc'
+    assert codec.decode(field, codec.encode(field, '')) == b''
+
+
+def test_unicode():
+    codec = ScalarCodec(StringType())
+    field = UnischemaField(name='field_string', numpy_dtype=np.unicode_, shape=(), codec=codec, nullable=False)
+
+    assert codec.decode(field, codec.encode(field, 'abc')) == 'abc'
+    assert codec.decode(field, codec.encode(field, '')) == ''
+
+
+@pytest.mark.parametrize('spark_numpy_types', [
+    (ByteType, np.uint8),
+    (ByteType, np.int8),
+    (ShortType, np.int16),
+    (IntegerType, np.int32),
+    (LongType, np.int64),
+])
+def test_numeric_types(spark_numpy_types):
+    spark_type, numpy_type = spark_numpy_types
+
+    codec = ScalarCodec(spark_type())
+    field = UnischemaField(name='field_int', numpy_dtype=numpy_type, shape=(), codec=codec, nullable=False)
+
+    min_val, max_val = np.iinfo(numpy_type).min, np.iinfo(numpy_type).max
+
+    assert codec.decode(field, codec.encode(field, numpy_type(min_val))) == min_val
+    assert codec.decode(field, codec.encode(field, numpy_type(max_val))) == max_val
+
+
+def test_scalar_codec_decimal():
+    codec = ScalarCodec(DecimalType(4, 3))
+    field = UnischemaField(name='field_decimal', numpy_dtype=Decimal, shape=(), codec=codec, nullable=False)
+
+    value = Decimal('123.4567')
+    assert codec.decode(field, codec.encode(field, value)) == value
+
+
+def test_bad_encoded_data_shape():
+    codec = ScalarCodec(IntegerType())
+    field = UnischemaField(name='field_int', numpy_dtype=np.int32, shape=(), codec=codec, nullable=False)
+    with pytest.raises(TypeError):
+        codec.decode(field, codec.encode(field, np.asarray([10, 10])))
+
+
+def test_bad_unischema_field_shape():
+    codec = ScalarCodec(IntegerType())
+    field = UnischemaField(name='field_int', numpy_dtype=np.int32, shape=(1,), codec=codec, nullable=False)
+    with pytest.raises(ValueError, match='must be an empty tuple'):
+        codec.encode(field, np.int32(1))


### PR DESCRIPTION
A single test_codecs.py became messy and hard to track.