### PR TITLE
Alias `make_reader` via importing it rather creating a separate symbol

### DIFF
--- a/petastorm/__init__.py
+++ b/petastorm/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import petastorm.reader
+from petastorm.reader import make_reader  # noqa: F401
 
 __version__ = '0.4.2'
-
-make_reader = petastorm.reader.make_reader


### PR DESCRIPTION
This enables doc strings and symbol navigation work smoother from within IDEs.