### PR TITLE
Fix "Unnecessary pass statement" lint failure

### DIFF
--- a/petastorm/cache.py
+++ b/petastorm/cache.py
@@ -30,7 +30,6 @@ class CacheBase(object):
             value is present in the cache.
         :return: A value from cache
         """
-        pass
 
 
 class NullCache(CacheBase):

--- a/petastorm/etl/__init__.py
+++ b/petastorm/etl/__init__.py
@@ -48,4 +48,3 @@ class RowGroupIndexerBase(object):
     @abc.abstractmethod
     def build_index(self, decoded_rows, piece_index):
         """ index values in given rows."""
-        pass

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -38,7 +38,6 @@ class PetastormMetadataError(Exception):
     Error to specify when the petastorm metadata does not exist, does not contain the necessary information,
     or is corrupt/invalid.
     """
-    pass
 
 
 class PetastormMetadataGenerationError(Exception):
@@ -46,7 +45,6 @@ class PetastormMetadataGenerationError(Exception):
     Error to specify when petastorm could not generate metadata properly.
     This error is usually accompanied with a message to try to regenerate dataset metadata.
     """
-    pass
 
 
 @contextmanager

--- a/petastorm/reader_impl/shuffling_buffer.py
+++ b/petastorm/reader_impl/shuffling_buffer.py
@@ -30,7 +30,6 @@ class ShufflingBufferBase(object):
         :param items: items to be added to the shuffling buffer.
         :return: None
         """
-        pass
 
     @abc.abstractmethod
     def retrieve(self):
@@ -38,7 +37,6 @@ class ShufflingBufferBase(object):
 
         :return: The selected item.
         """
-        pass
 
     @abc.abstractmethod
     def can_add(self):
@@ -46,7 +44,6 @@ class ShufflingBufferBase(object):
 
         :return: A boolean indicating whether an item can be added to the buffer at the time.
         """
-        pass
 
     @abc.abstractmethod
     def can_retrieve(self):
@@ -54,7 +51,6 @@ class ShufflingBufferBase(object):
 
         :return: A boolean indicating whether an item can be returned from the buffer at the time.
         """
-        pass
 
     @abc.abstractproperty
     def size(self):
@@ -62,7 +58,6 @@ class ShufflingBufferBase(object):
 
         :return: number of elements currently present in the buffer
         """
-        pass
 
     @abc.abstractmethod
     def finish(self):
@@ -73,7 +68,6 @@ class ShufflingBufferBase(object):
 
         :return: number of elements currently present in the buffer
         """
-        pass
 
 
 class NoopShufflingBuffer(ShufflingBufferBase):

--- a/petastorm/reader_impl/worker_loop.py
+++ b/petastorm/reader_impl/worker_loop.py
@@ -31,7 +31,6 @@ _LOOP_IDLE_TIME_SEC = 0.001  # 1 ms
 class EOFSentinel(object):
     """This is a 'poison' object being queued into the output queue to signal that no further data will be arriving.
     This would happen when the number of epochs is limited and we are done reading all the data."""
-    pass
 
 
 def _decode_row_dispatcher(decoder, row):

--- a/petastorm/selectors.py
+++ b/petastorm/selectors.py
@@ -23,12 +23,10 @@ class RowGroupSelectorBase(object):
     @abc.abstractmethod
     def get_index_names(self):
         """ Return list of indexes required for given selector."""
-        pass
 
     @abc.abstractmethod
     def select_row_groups(self, index_dict):
         """ Return set of row groups which are selected."""
-        pass
 
 
 class SingleIndexSelector(RowGroupSelectorBase):

--- a/petastorm/workers_pool/__init__.py
+++ b/petastorm/workers_pool/__init__.py
@@ -16,14 +16,11 @@
 class EmptyResultError(RuntimeError):
     """Exception used to signal that there are no new elements in the queue and no new elements are expected, unless
     ventilate is called again"""
-    pass
 
 
 class TimeoutWaitingForResultError(RuntimeError):
     """Indicates that timeout has elapsed while waiting for a result"""
-    pass
 
 
 class VentilatedItemProcessedMessage(object):
     """Object to signal that a worker has completed processing an item from the ventilation queue"""
-    pass

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -32,7 +32,6 @@ _VERIFY_END_OF_VENTILATION_PERIOD = 0.1
 
 class WorkerTerminationRequested(Exception):
     """This exception will be raised if a thread is being stopped while waiting to write to the results queue."""
-    pass
 
 
 class WorkerThread(Thread):

--- a/petastorm/workers_pool/ventilator.py
+++ b/petastorm/workers_pool/ventilator.py
@@ -40,7 +40,6 @@ class Ventilator(object):
         """A callback for the worker pool to tell the ventilator that it has processed an item from the ventilation
         queue. This allows the ventilator to know how many items are currently on the ventilation queue.
         This function should not have a return value."""
-        pass
 
     @abstractmethod
     def completed(self):


### PR DESCRIPTION
With newer version of pylint, we started getting these errors. Removing
`pass` statements where a docstring is present to avoid the failure.