### PR TITLE
Fix dataset sharding.

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -14,7 +14,6 @@
 
 import collections
 import logging
-import os
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 import six
@@ -355,9 +354,7 @@ class Reader(object):
 
         # We hash on the relative path of each parquet file to guarantee consistency between different reader
         # constructions even after moving the dataset
-        filtered_row_group_indexes = [index for index in filtered_row_group_indexes
-                                      if hash(os.path.relpath(row_groups[index].path, dataset.paths)) %
-                                      shard_count == cur_shard]
+        filtered_row_group_indexes = [index for index in filtered_row_group_indexes if index % shard_count == cur_shard]
         return filtered_row_group_indexes
 
     def _apply_row_group_selector(self, dataset, rowgroup_selector, filtered_row_group_indexes):

--- a/petastorm/reader_impl/reader_v2.py
+++ b/petastorm/reader_impl/reader_v2.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 import collections
 import logging
-import os
 import threading
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 
 import six
-from concurrent.futures import ThreadPoolExecutor
 from pyarrow import parquet as pq
 from six.moves.queue import Queue
 from six.moves.urllib.parse import urlparse
@@ -151,7 +150,8 @@ class ReaderV2(object):
         epoch_items = self._apply_row_drop_partition(filtered_row_groups, shuffle_row_drop_partitions)
 
         # 4. Launch a new thread running `worker_loop` function.
-        def epochs_iterator(): return epoch_generator(epoch_items, num_epochs, shuffle_row_groups)
+        def epochs_iterator():
+            return epoch_generator(epoch_items, num_epochs, shuffle_row_groups)
 
         self._results_queue = Queue(_OUTPUT_QUEUE_SIZE)
 
@@ -233,8 +233,7 @@ class ReaderV2(object):
         # We hash on the relative path of each parquet file to guarantee consistency between different reader
         # constructions even after moving the dataset
         filtered_row_group_indexes = [index for index in filtered_row_group_indexes
-                                      if hash(os.path.relpath(row_groups[index].path, dataset.paths)) %
-                                      num_training_partitions == training_partition]
+                                      if index % num_training_partitions == training_partition]
         return filtered_row_group_indexes
 
     def _apply_row_group_selector(self, dataset, rowgroup_selector, filtered_row_group_indexes):

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -216,7 +216,11 @@ def test_partition_multi_node(synthetic_dataset, reader_factory):
                 results_1.append(actual)
                 expected.append(next(d for d in synthetic_dataset.data if d['id'] == actual['id']))
 
+            assert results_1, 'Shard 0 is expected to have at least one row'
+
             results_2 = [dict(row._asdict()) for row in reader_2]
+
+            assert results_2, 'Shard 0 is expected to have at least one row'
 
             # Since order is non deterministic, we need to sort results by id
             results_1.sort(key=lambda x: x['id'])


### PR DESCRIPTION
Prevoiusly were using hash() function on a parquet file path to shard. In Python3, value of hash() function depends on PYTHONHASHSEED, which is 'random' by default.
This means that on different machines we would have got different hashing, hence shards would likely overlap.

Changed partition assignment to be based on our internal integer value of a rowgroup. For immutable datasets rowgroup ids are stable. Sharding by rowgroup has better granularity, since multiple rowgroups can be found in a single parquet file and some parquet files may have more rowgroups than others.