### PR TITLE
Configure ProcessPool with a serializer object instance

### DIFF
--- a/petastorm/benchmark/throughput.py
+++ b/petastorm/benchmark/throughput.py
@@ -27,6 +27,8 @@ import tensorflow as tf
 from petastorm import make_reader
 from petastorm.etl.dataset_metadata import get_schema_from_dataset_url
 from petastorm.reader import ReaderV2
+from petastorm.reader_impl.pickle_serializer import PickleSerializer
+from petastorm.reader_impl.pyarrow_serializer import PyArrowSerializer
 from petastorm.reader_impl.same_thread_executor import SameThreadExecutor
 from petastorm.reader_impl.shuffling_buffer import RandomShufflingBuffer
 from petastorm.tf_utils import tf_tensors
@@ -260,7 +262,8 @@ def _create_worker_pool(pool_type, workers_count, profiling_enabled, pyarrow_ser
     if pool_type == WorkerPoolType.THREAD:
         worker_pool = ThreadPool(workers_count, profiling_enabled=profiling_enabled)
     elif pool_type == WorkerPoolType.PROCESS:
-        worker_pool = ProcessPool(workers_count, pyarrow_serialize=pyarrow_serialize)
+        worker_pool = ProcessPool(workers_count,
+                                  serializer=PyArrowSerializer() if pyarrow_serialize else PickleSerializer())
     elif pool_type == WorkerPoolType.NONE:
         worker_pool = DummyPool()
     else:

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -25,6 +25,8 @@ from petastorm.fs_utils import FilesystemResolver
 from petastorm.local_disk_cache import LocalDiskCache
 from petastorm.ngram import NGram
 from petastorm.predicates import PredicateBase
+from petastorm.reader_impl.pickle_serializer import PickleSerializer
+from petastorm.reader_impl.pyarrow_serializer import PyArrowSerializer
 from petastorm.reader_impl.reader_v2 import ReaderV2
 from petastorm.reader_impl.same_thread_executor import SameThreadExecutor
 from petastorm.reader_impl.shuffling_buffer import NoopShufflingBuffer, RandomShufflingBuffer
@@ -131,7 +133,11 @@ def make_reader(dataset_url,
         if reader_pool_type == 'thread':
             reader_pool = ThreadPool(workers_count)
         elif reader_pool_type == 'process':
-            reader_pool = ProcessPool(workers_count, pyarrow_serialize=pyarrow_serialize)
+            if pyarrow_serialize:
+                serializer = PyArrowSerializer()
+            else:
+                serializer = PickleSerializer()
+            reader_pool = ProcessPool(workers_count, serializer)
         elif reader_pool_type == 'dummy':
             reader_pool = DummyPool()
         else:


### PR DESCRIPTION
…instead of a boolean flag.

We will need more flexibility with serializing results coming from ProcessPool when using PyArrow tables as the container for all data. `ArrowTableSerializer` is introduces as a third serialization option in another CL.