### PR TITLE
Make reading a non-petastorm dataset fail if contains Null values

### DIFF
--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -48,6 +48,9 @@ class ArrowReaderWorkerResultsQueueReader(object):
             for column in result_table.columns:
                 # Assume we get only one chunk since reader worker reads one rowgroup at a time
                 assert len(column.data.chunks) == 1
+                if column.data.chunks[0].null_count > 0:
+                    raise RuntimeError('Batching rows with null values is unsupported. Column %s contains nulls.',
+                                       column.name)
                 if column.type == pa.string():
                     result_dict[column.name] = column.data.chunks[0].to_pandas().astype(np.unicode_)
                 else:

--- a/petastorm/tests/conftest.py
+++ b/petastorm/tests/conftest.py
@@ -104,3 +104,15 @@ def scalar_dataset(request, tmpdir_factory):
         return dataset
 
     return maybe_cached_dataset(request.config, 'scalar', _pure_parquet_dataset_no_cache)
+
+
+@pytest.fixture(scope="session")
+def scalar_dataset_with_nulls(request, tmpdir_factory):
+    def _pure_parquet_dataset_no_cache():
+        path = tmpdir_factory.mktemp("data").strpath
+        url = 'file://' + path
+        data = create_test_scalar_dataset(url, 100, include_nulls=True)
+        dataset = SyntheticDataset(url=url, path=path, data=data)
+        return dataset
+
+    return maybe_cached_dataset(request.config, 'scalar_with_nulls', _pure_parquet_dataset_no_cache)

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -32,6 +32,8 @@ from petastorm.tests.test_end_to_end_predicates_impl import \
     PartitionKeyInSetPredicate, EqualPredicate, VectorizedEqualPredicate
 from petastorm.unischema import UnischemaField, Unischema
 
+NOT_NULLABLE_FIELDS = [f for f in TestSchema.fields.values() if not f.nullable]
+
 # pylint: disable=unnecessary-lambda
 MINIMAL_READER_FLAVOR_FACTORIES = [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
@@ -47,11 +49,10 @@ ALL_READER_FLAVOR_FACTORIES = MINIMAL_READER_FLAVOR_FACTORIES + [
     lambda url, **kwargs: make_reader(url, workers_count=2, reader_engine='experimental_reader_v2', **kwargs),
 ]
 
-SCALAR_FIELDS = [f for f in TestSchema.fields.values() if isinstance(f.codec, ScalarCodec)]
-
 SCALAR_ONLY_READER_FACTORIES = [
-    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs),
-    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='process', workers_count=2, **kwargs),
+    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', schema_fields=NOT_NULLABLE_FIELDS, **kwargs),
+    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='process', schema_fields=NOT_NULLABLE_FIELDS,
+                                            workers_count=2, **kwargs),
 ]
 
 
@@ -167,7 +168,7 @@ def test_reading_subset_of_columns_using_regex(synthetic_dataset, reader_factory
 
 @pytest.mark.parametrize('reader_factory', [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
-    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs),
+    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', schema_fields=NOT_NULLABLE_FIELDS, **kwargs),
     lambda url, **kwargs: ReaderV2(url, loader_pool=SameThreadExecutor(), decoder_pool=SameThreadExecutor(), **kwargs)])
 def test_shuffle(synthetic_dataset, reader_factory):
     rows_count = len(synthetic_dataset.data)
@@ -189,7 +190,7 @@ def test_shuffle(synthetic_dataset, reader_factory):
 
 @pytest.mark.parametrize('reader_factory', [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
-    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs),
+    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', schema_fields=NOT_NULLABLE_FIELDS, **kwargs),
     lambda url, **kwargs: ReaderV2(url, loader_pool=SameThreadExecutor(), decoder_pool=SameThreadExecutor(), **kwargs)])
 def test_shuffle_drop_ratio(synthetic_dataset, reader_factory):
     # Read ids twice without shuffle: assert we have the same array and all expected ids are in the array
@@ -318,7 +319,7 @@ def test_partition_value_error(synthetic_dataset, reader_factory):
 
 @pytest.mark.parametrize('reader_factory', [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
-    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs),
+    lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', schema_fields=NOT_NULLABLE_FIELDS, **kwargs),
     lambda url, **kwargs: ReaderV2(url, loader_pool=SameThreadExecutor(), decoder_pool=SameThreadExecutor(), **kwargs)
 ])
 def test_stable_pieces_order(synthetic_dataset, reader_factory):

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -63,4 +63,13 @@ def test_specify_columns_to_read(scalar_dataset, reader_factory):
         assert set(sample._asdict().keys()) == {'id', 'float64'}
         assert sample.float64.size > 0
 
+
+@pytest.mark.parametrize('reader_factory', _D)
+def test_raise_error_with_null_fields(scalar_dataset_with_nulls, reader_factory):
+    """Batching with None values is currently not supported since we use numpy arrays as return values and
+    these do not support null values."""
+    with reader_factory(scalar_dataset_with_nulls.url) as reader:
+        with pytest.raises(RuntimeError, match='Batching rows with null values is unsupported'):
+            next(reader)
+
 # TODO(yevgeni): missing tests: https://github.com/uber/petastorm/issues/257


### PR DESCRIPTION
Previously, unexpected conversion to float was occuring when an int column contained Nulls