### PR TITLE
Support a regex pattern string when specifying `make_reader`'s `schem…

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -74,8 +74,8 @@ def make_reader(dataset_url,
     :param dataset_url: an filepath or a url to a parquet directory,
         e.g. ``'hdfs://some_hdfs_cluster/user/yevgeni/parquet8'``, or ``'file:///tmp/mydataset'``
         or ``'s3://bucket/mydataset'``.
-    :param schema_fields: Either list of unischema fields to subset, or ``None`` to read all fields.
-            OR an NGram object, then it will return an NGram of the specified properties.
+    :param schema_fields: Can be: a list of unischema fields and/or regex pattern strings; ``None`` to read all fields;
+            an NGram object, then it will return an NGram of the specified fields.
     :param reader_pool_type: A string denoting the reader pool type. Should be one of ['thread', 'process', 'dummy']
         denoting a thread pool, process pool, or running everything in the master thread. Defaults to 'thread'
     :param workers_count: An int for the number of workers to use in the reader pool. This only is used for the

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -153,6 +153,18 @@ def test_reading_subset_of_columns(synthetic_dataset, reader_factory):
             np.testing.assert_equal(expected['id2'], actual['id2'])
 
 
+@pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES)
+def test_reading_subset_of_columns_using_regex(synthetic_dataset, reader_factory):
+    """Just a bunch of read and compares of all values to the expected values"""
+    with reader_factory(synthetic_dataset.url, schema_fields=['id$', 'id_.*$', 'partition_key$']) as reader:
+        # Read a bunch of entries from the dataset and compare the data to reference
+        for row in reader:
+            actual = dict(row._asdict())
+            assert set(actual.keys()) == {'id_float', 'id_odd', 'id', 'partition_key'}
+            expected = next(d for d in synthetic_dataset.data if d['id'] == actual['id'])
+            np.testing.assert_equal(expected['id_float'], actual['id_float'])
+
+
 @pytest.mark.parametrize('reader_factory', [
     lambda url, **kwargs: make_reader(url, reader_pool_type='dummy', **kwargs),
     lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs),

--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -175,6 +175,39 @@ class UnischemaTest(unittest.TestCase):
             TestSchema.create_schema_view([UnischemaField('id', np.int64, (), ScalarCodec(LongType()), False)])
         self.assertTrue('does not belong to the schema' in str(ex.exception))
 
+    def test_create_schema_view_using_unischema_fields(self):
+        TestSchema = Unischema('TestSchema', [
+            UnischemaField('int_field', np.int8, (), ScalarCodec(IntegerType()), False),
+            UnischemaField('string_field', np.string_, (), ScalarCodec(StringType()), False),
+        ])
+        view = TestSchema.create_schema_view([TestSchema.int_field])
+        self.assertEqual(set(view.fields.keys()), {'int_field'})
+
+    def test_create_schema_view_using_regex(self):
+        TestSchema = Unischema('TestSchema', [
+            UnischemaField('int_field', np.int8, (), ScalarCodec(IntegerType()), False),
+            UnischemaField('string_field', np.string_, (), ScalarCodec(StringType()), False),
+        ])
+        view = TestSchema.create_schema_view(['int.*$'])
+        self.assertEqual(set(view.fields.keys()), {'int_field'})
+
+    def test_create_schema_view_using_regex_and_unischema_fields(self):
+        TestSchema = Unischema('TestSchema', [
+            UnischemaField('int_field', np.int8, (), ScalarCodec(IntegerType()), False),
+            UnischemaField('string_field', np.string_, (), ScalarCodec(StringType()), False),
+            UnischemaField('other_string_field', np.string_, (), ScalarCodec(StringType()), False),
+        ])
+        view = TestSchema.create_schema_view(['int.*$', TestSchema.string_field])
+        self.assertEqual(set(view.fields.keys()), {'int_field', 'string_field'})
+
+    def test_create_schema_view_no_field_matches_regex(self):
+        TestSchema = Unischema('TestSchema', [
+            UnischemaField('int_field', np.int8, (), ScalarCodec(IntegerType()), False),
+            UnischemaField('string_field', np.string_, (), ScalarCodec(StringType()), False),
+        ])
+        view = TestSchema.create_schema_view(['bogus'])
+        self.assertEqual(len(view.fields), 0)
+
     def test_name_property(self):
         TestSchema = Unischema('TestSchema', [
             UnischemaField('nullable', np.int32, (), ScalarCodec(StringType()), True),


### PR DESCRIPTION
…a_fields` argument.

Extended Unischema.create_schema_view functionality to support regular expression patterns.
Later will use this feature to support querying a subset of fields in `make_batch_reader`.