### PR TITLE
Allow user to specify a subset of fields to read.

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -226,6 +226,7 @@ def make_reader(dataset_url,
 
 
 def make_batch_reader(dataset_url,
+                      schema_fields=None,
                       reader_pool_type='thread', workers_count=10,
                       shuffle_row_groups=True, shuffle_row_drop_partitions=1,
                       predicate=None,
@@ -247,6 +248,8 @@ def make_batch_reader(dataset_url,
     :param dataset_url: an filepath or a url to a parquet directory,
         e.g. ``'hdfs://some_hdfs_cluster/user/yevgeni/parquet8'``, or ``'file:///tmp/mydataset'``
         or ``'s3://bucket/mydataset'``.
+    :param schema_fields: A list of regex pattern strings. Only columns matching at least one of the
+        patterns in the list will be loaded.
     :param reader_pool_type: A string denoting the reader pool type. Should be one of ['thread', 'process', 'dummy']
         denoting a thread pool, process pool, or running everything in the master thread. Defaults to 'thread'
     :param workers_count: An int for the number of workers to use in the reader pool. This only is used for the
@@ -310,6 +313,7 @@ def make_batch_reader(dataset_url,
         raise ValueError('Unknown reader_pool_type: {}'.format(reader_pool_type))
 
     return Reader(filesystem, dataset_path,
+                  schema_fields=schema_fields,
                   worker_class=ArrowReaderWorker,
                   reader_pool=reader_pool,
                   shuffle_row_groups=shuffle_row_groups,

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -54,4 +54,13 @@ def test_simple_read(scalar_dataset, reader_factory):
     with reader_factory(scalar_dataset.url) as reader:
         _check_simple_reader(reader, scalar_dataset.data)
 
+
+@pytest.mark.parametrize('reader_factory', _D)
+def test_specify_columns_to_read(scalar_dataset, reader_factory):
+    """Just a bunch of read and compares of all values to the expected values using the different reader pools"""
+    with reader_factory(scalar_dataset.url, schema_fields=['id', 'float.*$']) as reader:
+        sample = next(reader)
+        assert set(sample._asdict().keys()) == {'id', 'float64'}
+        assert sample.float64.size > 0
+
 # TODO(yevgeni): missing tests: https://github.com/uber/petastorm/issues/257


### PR DESCRIPTION
Now `make_batch_reader` can take a list of regex patterns as the `schema_fields` arguments.