### PR TITLE
Adding DateType() and Timestamp() types support

### DIFF
--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -134,6 +134,9 @@ def _assert_fields_eq(actual, desired):
 
     if isinstance(desired, Decimal):
         np.testing.assert_equal(desired, Decimal(actual))
+    elif issubclass(desired.dtype.type, np.datetime64):
+        # tf_utils will convert timestamps to ns from epoch int64 value.
+        assert desired.astype('<M8[ns]').astype(np.int64) == actual
     else:
         np.testing.assert_equal(desired, actual)
 

--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -241,6 +241,11 @@ class UnischemaTest(unittest.TestCase):
             pa.field('fixed_size_binary', pa.binary(10)),
             pa.field('variable_size_binary', pa.binary()),
             pa.field('decimal', pa.decimal128(3, 4)),
+            pa.field('timestamp_s', pa.timestamp('s')),
+            pa.field('timestamp_ns', pa.timestamp('ns')),
+            pa.field('date_32', pa.date32()),
+            pa.field('date_64', pa.date64()),
+            pa.field('timestamp_ns', pa.timestamp('ns')),
         ])
 
         mock_dataset = _mock_parquet_dataset([], arrow_schema)

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -37,6 +37,7 @@ _NUMPY_TO_TF_DTYPES_MAPPING = {
     np.str_: tf.string,
     np.bool_: tf.bool,
     Decimal: tf.string,
+    np.datetime64: tf.int64,
 }
 
 # Name of an op in the TF graph used for the random shuffling queue. This name can be used by diagnostics code that
@@ -71,6 +72,10 @@ def _sanitize_field_tf_types(sample):
             # Normalizing decimals only to get rid of the trailing zeros (makes testing easier, assuming has
             # no other effect)
             next_sample_dict[k] = str(v.normalize())
+        elif isinstance(v, np.ndarray) and np.issubdtype(v.dtype, np.datetime64):
+            # Convert to nanoseconds from POSIX epoch
+            next_sample_dict[k] = (v - np.datetime64('1970-01-01T00:00:00.0Z'))\
+                .astype('timedelta64[ns]').astype(np.int64)
         elif isinstance(v, np.ndarray) and v.dtype == np.uint16:
             next_sample_dict[k] = v.astype(np.int32)
 


### PR DESCRIPTION
Now, we can read from a Parquet store that has native parquet dates and timestamps.
When reading into Tensorflow, the values will appear as int64 containing number of nanoseconds from unix epoch.