### PR TITLE
Adding transform-on-worker thread/pool functionality.

### DIFF
--- a/petastorm/__init__.py
+++ b/petastorm/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 from petastorm.reader import make_reader, make_batch_reader  # noqa: F401
+from petastorm.transform import TransformSpec  # noqa: F401
 
 __version__ = '0.5.1'

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -16,7 +16,7 @@ from time import sleep
 import pyarrow.parquet as pq
 import pytest
 
-from petastorm import make_reader
+from petastorm import make_reader, TransformSpec
 from petastorm.reader import Reader
 
 # pylint: disable=unnecessary-lambda
@@ -94,3 +94,10 @@ def test_invalid_reader_pool_type(synthetic_dataset, reader_factory):
 def test_invalid_reader_engine(synthetic_dataset, reader_factory):
     with pytest.raises(ValueError, match='Supported reader_engine values'):
         make_reader(synthetic_dataset.url, reader_engine='bogus reader engine')
+
+
+@pytest.mark.parametrize('reader_factory', READER_FACTORIES)
+def test_reader_engine_v2_with_transform_is_not_supported(synthetic_dataset, reader_factory):
+    with pytest.raises(NotImplementedError):
+        make_reader(synthetic_dataset.url, reader_engine='experimental_reader_v2',
+                    transform_spec=TransformSpec(lambda x: x))

--- a/petastorm/transform.py
+++ b/petastorm/transform.py
@@ -1,0 +1,63 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from petastorm.unischema import UnischemaField, Unischema
+
+
+class TransformSpec(object):
+    def __init__(self, func, edit_fields=None, removed_fields=None):
+        """TransformSpec defines a user transformation that is applied to a loaded row on a worker thread/process.
+
+        The object defines the function (callable) that perform the transform as well as the
+        schema transform: pre-transform-schema to post-transform-schema.
+
+        ``func`` argument is a callable which takes a row as its parameter and returns a modified row.
+        ``edit_fields`` and ``removed_fields`` define how the schema to which
+        ``edit_fields`` and ``removed_fields`` are define mutation operation performed on the original schema that
+        produce a post-transform schema. ``func`` return value must comply to this post-transform schema.
+
+        :param func: A callable. The function is called on the worker thread. It takes a dictionary that complies to
+          the input schema and must return a dictionary that complies to a post-transform schema.
+        :param edit_fields: Optional. A list of 4-tuples with the following fields:
+          ``(name, numpy_dtype, shape, is_nullable)``
+        :param removed_fields: Optional. A list of field names that will be removed from the original schema.
+        """
+        self.func = func
+        self.edit_fields = edit_fields or []
+        self.removed_fields = removed_fields or []
+
+
+def transform_schema(schema, transform_spec):
+    """Creates a post-transform given a pre-transform schema and a transform_spec with mutation instructions.
+
+    :param schema: A pre-transform schema
+    :param transform_spec: a TransformSpec object with mutation instructions.
+    :return: A post-transform schema
+    """
+    removed_fields = set(transform_spec.removed_fields)
+    unknown_field_names = removed_fields - set(schema.fields.keys())
+    if unknown_field_names:
+        raise ValueError('Unexpected field names found in TransformSpec remove_fields list: "%s". '
+                         'Valid values are "%s".',
+                         ', '.join(removed_fields), ', '.join(schema.fields.keys()))
+
+    exclude_fields = {f[0] for f in transform_spec.edit_fields} | removed_fields
+    fields = [v for k, v in schema.fields.items() if k not in exclude_fields]
+
+    for field_to_edit in transform_spec.edit_fields:
+        edited_unischema_field = UnischemaField(name=field_to_edit[0], numpy_dtype=field_to_edit[1],
+                                                shape=field_to_edit[2], codec=None, nullable=field_to_edit[3])
+        fields.append(edited_unischema_field)
+
+    return Unischema(schema.name + '_transformed', fields)

--- a/petastorm/workers_pool/exec_in_new_process.py
+++ b/petastorm/workers_pool/exec_in_new_process.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 from tempfile import mkstemp
 
+import dill
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +37,7 @@ def exec_in_new_process(func, *args, **kargs):
     # Store function handle and arguments into a pickle
     new_process_runnable_handle, new_process_runnable_file = mkstemp(suffix='runnable')
     with os.fdopen(new_process_runnable_handle, 'wb') as f:
-        pickle.dump((func, args, kargs), f)
+        dill.dump((func, args, kargs), f)
 
     bootstrap_package_name = '{}.{}'.format(__package__, os.path.splitext(os.path.basename(__file__))[0])
     # Popen this script (__main__) below will be an entry point

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ with io.open('petastorm/__init__.py', 'rt', encoding='utf8') as f:
         raise ImportError('Could not find __version__ in petastorm/__init__.py')
 
 REQUIRED_PACKAGES = [
+    'dill>=0.2.1',
     'diskcache>=3.0.0',
     'numpy>=1.13.3',
     'pandas>=0.19.0',


### PR DESCRIPTION
A user needs to specify transform_spec when calling `make_reader`.
The transform-spec defines both the function and the post-transform scheme of the data.

output_schema attribute was added to the Reader interface.

TODO list (will open issues once the PR lands)
- Add transform examples to the tutorials
- Add proper unit test for the new transform.py module
- Add transform functionality to `make_batch_reader`
- Validate the return value of the transform function conforms to the post-transform schema and raise an error if not.
- Verify transform functionality when using ngram
