### PR TITLE
Parameterize the hdfs-driver in the API to support libhdfs

### DIFF
--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -365,13 +365,15 @@ def get_schema(dataset):
     return schema
 
 
-def get_schema_from_dataset_url(dataset_url):
+def get_schema_from_dataset_url(dataset_url, hdfs_driver='libhdfs3'):
     """Returns a :class:`petastorm.unischema.Unischema` object loaded from a dataset specified by a url.
 
     :param dataset_url: A dataset URL
+    :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
+        libhdfs (java through JNI) or libhdfs3 (C++)
     :return: A :class:`petastorm.unischema.Unischema` object
     """
-    resolver = FilesystemResolver(dataset_url)
+    resolver = FilesystemResolver(dataset_url, hdfs_driver=hdfs_driver)
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
                                 validate_schema=False)
 

--- a/petastorm/etl/metadata_util.py
+++ b/petastorm/etl/metadata_util.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     parser.add_argument('--skip-index', nargs='+', type=str,
                         help='Donot display indexed values for given fields')
     parser.add_argument('--hdfs-driver', type=str,
-                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are' \
-                             'libhdfs (java through JNI) or libhdfs3 (C++)')
+                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
+                             'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
 
     args = parser.parse_args()
 

--- a/petastorm/etl/metadata_util.py
+++ b/petastorm/etl/metadata_util.py
@@ -36,6 +36,9 @@ if __name__ == "__main__":
                         help='Print index values (dataset piece indexes)')
     parser.add_argument('--skip-index', nargs='+', type=str,
                         help='Donot display indexed values for given fields')
+    parser.add_argument('--hdfs-driver', type=str,
+                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are' \
+                             'libhdfs (java through JNI) or libhdfs3 (C++)')
 
     args = parser.parse_args()
 
@@ -43,7 +46,7 @@ if __name__ == "__main__":
         args.dataset_url = args.dataset_url[:-1]
 
     # Create pyarrow file system
-    resolver = FilesystemResolver(args.dataset_url)
+    resolver = FilesystemResolver(args.dataset_url, hdfs_driver=args.hdfs_driver)
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
                                 validate_schema=False)
 

--- a/petastorm/etl/metadata_util.py
+++ b/petastorm/etl/metadata_util.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
                         help='Print index values (dataset piece indexes)')
     parser.add_argument('--skip-index', nargs='+', type=str,
                         help='Donot display indexed values for given fields')
-    parser.add_argument('--hdfs-driver', type=str,
+    parser.add_argument('--hdfs-driver', type=str, default='libhdfs3',
                         help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
                              'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
 

--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -130,8 +130,8 @@ def _main(args):
                         help='Whether to use the parquet summary metadata format.'
                              ' Not scalable for large amounts of columns and/or row groups.')
     parser.add_argument('--hdfs-driver', type=str,
-                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are' \
-                             'libhdfs (java through JNI) or libhdfs3 (C++)')
+                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
+                             'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
     args = parser.parse_args(args)
 
     # Open Spark Session

--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -129,7 +129,7 @@ def _main(args):
     parser.add_argument('--use-summary-metadata', action='store_true',
                         help='Whether to use the parquet summary metadata format.'
                              ' Not scalable for large amounts of columns and/or row groups.')
-    parser.add_argument('--hdfs-driver', type=str,
+    parser.add_argument('--hdfs-driver', type=str, default='libhdfs3',
                         help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
                              'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
     args = parser.parse_args(args)

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -41,6 +41,8 @@ class FilesystemResolver(object):
         :param dataset_url: The hdfs URL or absolute path to the dataset
         :param hadoop_configuration: an optional hadoop configuration
         :param connector: the HDFS connector object to use (ONLY override for testing purposes)
+        :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
+        libhdfs (java through JNI) or libhdfs3 (C++)
         """
         # Cache both the original URL and the resolved, urlparsed dataset_url
         self._dataset_url = dataset_url

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -138,7 +138,7 @@ def make_reader(dataset_url,
     # rowgroup. Using PyDictReaderWorker or ReaderV2 implementation is very inefficient as it processes data on a
     # row by row basis. ArrowReaderWorker (used by make_batch_reader) is much more efficient in these cases.
     try:
-        dataset_metadata.get_schema_from_dataset_url(dataset_url)
+        dataset_metadata.get_schema_from_dataset_url(dataset_url, hdfs_driver=hdfs_driver)
     except PetastormMetadataError:
         raise RuntimeError('Currently make_reader supports reading only Petastorm datasets. '
                            'To read from a non-Petastorm Parquet store use make_batch_reader')

--- a/petastorm/reader_impl/reader_v2.py
+++ b/petastorm/reader_impl/reader_v2.py
@@ -46,7 +46,8 @@ class ReaderV2(object):
     def __init__(self, dataset_url, schema_fields=None, predicate=None, rowgroup_selector=None,
                  num_epochs=1, sequence=None, cur_shard=None, shard_count=None,
                  read_timeout_s=None, cache=None, loader_pool=None, decoder_pool=None, shuffling_queue=None,
-                 shuffle_row_groups=True, shuffle_row_drop_partitions=1, pyarrow_filesystem=None, hdfs_driver='libhdfs3'):
+                 shuffle_row_groups=True, shuffle_row_drop_partitions=1, pyarrow_filesystem=None,
+                 hdfs_driver='libhdfs3'):
         """Initializes a reader object.
 
         :param dataset_url: an filepath or a url to a parquet directory,

--- a/petastorm/reader_impl/reader_v2.py
+++ b/petastorm/reader_impl/reader_v2.py
@@ -46,7 +46,7 @@ class ReaderV2(object):
     def __init__(self, dataset_url, schema_fields=None, predicate=None, rowgroup_selector=None,
                  num_epochs=1, sequence=None, cur_shard=None, shard_count=None,
                  read_timeout_s=None, cache=None, loader_pool=None, decoder_pool=None, shuffling_queue=None,
-                 shuffle_row_groups=True, shuffle_row_drop_partitions=1, pyarrow_filesystem=None):
+                 shuffle_row_groups=True, shuffle_row_drop_partitions=1, pyarrow_filesystem=None, hdfs_driver='libhdfs3'):
         """Initializes a reader object.
 
         :param dataset_url: an filepath or a url to a parquet directory,
@@ -77,6 +77,8 @@ class ReaderV2(object):
           a default ThreadPoolExecutor(5) will be used.
         :param loader_pool: An instance of a concurrent.futures pool executor used for decoding. If None,
           a default ThreadPoolExecutor(5) will be used.
+        :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
+        libhdfs (java through JNI) or libhdfs3 (C++)
 
         By default, `NullCache` implementation
         """
@@ -153,7 +155,7 @@ class ReaderV2(object):
 
         self._results_queue = Queue(_OUTPUT_QUEUE_SIZE)
 
-        loader = RowGroupLoader(dataset_url, self.schema, self.ngram, cache, worker_predicate)
+        loader = RowGroupLoader(dataset_url, self.schema, self.ngram, cache, worker_predicate, hdfs_driver=hdfs_driver)
         decoder = RowDecoder(self.schema, self.ngram)
         self._loader_pool = loader_pool or ThreadPoolExecutor(5)
         self._decoder_pool = decoder_pool or ThreadPoolExecutor(5)

--- a/petastorm/reader_impl/row_group_loader.py
+++ b/petastorm/reader_impl/row_group_loader.py
@@ -43,7 +43,7 @@ def _select_cols(a_dict, keys):
 
 
 class RowGroupLoader(object):
-    def __init__(self, dataset_url, schema, ngram, local_cache, worker_predicate):
+    def __init__(self, dataset_url, schema, ngram, local_cache, worker_predicate, hdfs_driver='libhdfs3'):
         """RowGroupLoader responsible for loading one rowgroup at a time. Rows returned are returned encoded.
 
         :param dataset_url: A url of a parquet dataset.
@@ -52,6 +52,8 @@ class RowGroupLoader(object):
           a single sample returned.
         :param local_cache: An instance of a rowgroup cache (CacheBase interface) object to be used.
         :param worker_predicate: An instance of predicate (PredicateBase interface)
+        :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
+        libhdfs (java through JNI) or libhdfs3 (C++)
         """
         self._dataset_url_parsed = urlparse(dataset_url)
         self._schema = schema
@@ -59,7 +61,7 @@ class RowGroupLoader(object):
         self._local_cache = local_cache
         self._worker_predicate = worker_predicate
 
-        resolver = FilesystemResolver(self._dataset_url_parsed)
+        resolver = FilesystemResolver(self._dataset_url_parsed, hdfs_driver=hdfs_driver)
         self._dataset = pq.ParquetDataset(
             resolver.get_dataset_path(),
             filesystem=resolver.filesystem(),

--- a/petastorm/tools/copy_dataset.py
+++ b/petastorm/tools/copy_dataset.py
@@ -30,9 +30,11 @@ from petastorm.etl.dataset_metadata import materialize_dataset, get_schema_from_
 from petastorm.tools.spark_session_cli import add_configure_spark_arguments, configure_spark
 from petastorm.fs_utils import FilesystemResolver
 
+
 def copy_dataset(spark, source_url, target_url, field_regex, not_null_fields, overwrite_output, partitions_count,
                  row_group_size_mb, hdfs_driver='libhdfs3'):
-    """Creates a copy of a dataset. A new dataset will optionally contain a subset of columns. Rows that have NULL
+    """
+    Creates a copy of a dataset. A new dataset will optionally contain a subset of columns. Rows that have NULL
     values in fields defined by ``not_null_fields`` argument are filtered out.
 
 
@@ -114,8 +116,8 @@ def args_parser():
     parser.add_argument('--row-group-size-mb', type=int, required=False,
                         help='Specifies the row group size in the created dataset')
     parser.add_argument('--hdfs-driver', type=str,
-                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are' \
-                             'libhdfs (java through JNI) or libhdfs3 (C++)')
+                        help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
+                             'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
 
     add_configure_spark_arguments(parser)
 

--- a/petastorm/tools/copy_dataset.py
+++ b/petastorm/tools/copy_dataset.py
@@ -115,7 +115,7 @@ def args_parser():
 
     parser.add_argument('--row-group-size-mb', type=int, required=False,
                         help='Specifies the row group size in the created dataset')
-    parser.add_argument('--hdfs-driver', type=str,
+    parser.add_argument('--hdfs-driver', type=str, default='libhdfs3',
                         help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
                              'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
 


### PR DESCRIPTION
In methods such as `materialize_dataset` the user can supply its own fs-handle
to use libhdfs instead of libhdfs3. But in other API methods, such as `dataset_as_rdd`,
there is currently no way for the user to specify to use libhdfs over libhdfs3.
This commit fixes that.

For example, before this commit, running the following command in a libhdfs environment:
```python
dataset_as_rdd(dataset_url, spark, [HelloWorldSchema.id, HelloWorldSchema.image1])
```
would give:
```
pyarrow.lib.ArrowIOError: Unable to load libhdfs3
```
With the changes of this commit you can specify the optional argument `hdfs_driver`
```
rdd = dataset_as_rdd(dataset_url, spark, [HelloWorldSchema.id, HelloWorldSchema.image1], hdfs_driver="libhdfs")
```
so that you can overwrite default value `libhdfs3` and make it compatible with libhdfs environments as well.

This PR is mostly to demonstrate what the minimal changes needed to make petastorm working with libhdfs on our cluster. Using these fixes in addition to a workaround for this bug: https://github.com/uber/petastorm/issues/287 (this is not included in this commit as it requires a bigger change to the API, we just have a temporary workaround in our fork at the moment, waiting for the next release of petastorm) all petastorm examples are working on our cluster with libhdfs. 
