### PR TITLE
[WIP] Fix batched read failures from S3

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -304,8 +304,7 @@ def make_batch_reader(dataset_url,
 
     resolver = FilesystemResolver(dataset_url, hdfs_driver=hdfs_driver)
     filesystem = resolver.filesystem()
-
-    dataset_path = resolver.parsed_dataset_url().path
+    dataset_path = resolver.get_dataset_path()
 
     if cache_type is None or cache_type == 'null':
         cache = NullCache()


### PR DESCRIPTION
# Problem
#300 - if `make_batch_reader()` is called on an `s3://` URL, it raises the following error:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid bucket name "": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$"
```. 
This occurs because `make_batch_reader` executes
```
dataset_path = resolver.parsed_dataset_url().path
```
which returns only the directory name. `make_reader()` executes
```
dataset_path = resolver.get_dataset_path()
```
which returns `/bucket/directory` and reads the data correctly.

# Solution
Set `dataset_path = resolver.get_dataset_path()` in `make_batch_reader()`.
