### PR TITLE
Deprecate DataLoader transform argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,11 +219,14 @@ The minimalist example below assumes the definition of a ``Net`` class and
         ])
         return (transform(mnist_row['image']), mnist_row['digit'])
 
-    with DataLoader(make_reader('file:///localpath/mnist/train', num_epochs=10),
-                    batch_size=64, transform=_transform_row) as train_loader:
+
+    transform = TransformSpec(_transform_row, removed_fields=['idx'])
+
+    with DataLoader(make_reader('file:///localpath/mnist/train', num_epochs=10,
+                                transform_spec=transform), batch_size=64) as train_loader:
         train(model, device, train_loader, 10, optimizer, 1)
-    with DataLoader(make_reader('file:///localpath/mnist/test', num_epochs=10),
-                    batch_size=1000, transform=_transform_row) as test_loader:
+    with DataLoader(make_reader('file:///localpath/mnist/test', num_epochs=10,
+                                transform_spec=transform), batch_size=1000) as test_loader:
         test(model, device, test_loader)
 
 PySpark and SQL

--- a/examples/mnist/pytorch_example.py
+++ b/examples/mnist/pytorch_example.py
@@ -29,7 +29,7 @@ import torch.optim as optim
 from torchvision import transforms
 
 from examples.mnist import DEFAULT_MNIST_DATA_PATH
-from petastorm import make_reader
+from petastorm import make_reader, TransformSpec
 from petastorm.pytorch import DataLoader
 
 
@@ -153,13 +153,17 @@ def main():
         loop_epochs = args.epochs
         reader_epochs = 1
 
+    transform = TransformSpec(_transform_row, removed_fields=['idx'])
+
     # Instantiate each petastorm Reader with a single thread, shuffle enabled, and appropriate epoch setting
     for epoch in range(1, loop_epochs + 1):
-        with DataLoader(make_reader('{}/train'.format(args.dataset_url), num_epochs=reader_epochs),
-                        batch_size=args.batch_size, transform=_transform_row) as train_loader:
+        with DataLoader(make_reader('{}/train'.format(args.dataset_url), num_epochs=reader_epochs,
+                                    transform_spec=transform),
+                        batch_size=args.batch_size) as train_loader:
             train(model, device, train_loader, args.log_interval, optimizer, epoch)
-        with DataLoader(make_reader('{}/test'.format(args.dataset_url), num_epochs=reader_epochs),
-                        batch_size=args.test_batch_size, transform=_transform_row) as test_loader:
+        with DataLoader(make_reader('{}/test'.format(args.dataset_url), num_epochs=reader_epochs,
+                                    transform_spec=transform),
+                        batch_size=args.test_batch_size) as test_loader:
             test(model, device, test_loader)
 
 

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -97,21 +97,19 @@ class DataLoader(object):
     runs out of samples.
     """
 
-    def __init__(self, reader, batch_size=1, collate_fn=decimal_friendly_collate, transform=None):
+    def __init__(self, reader, batch_size=1, collate_fn=decimal_friendly_collate):
         """
-        Initializes a data loader object, with a default collate and optional transform functions.
+        Initializes a data loader object, with a default collate.
 
         Number of epochs is defined by the configuration of the reader argument.
 
         :param reader: petastorm Reader instance
         :param batch_size: the number of items to return per batch; factored into the len() of this reader
         :param collate_fn: an optional callable to merge a list of samples to form a mini-batch.
-        :param transform: an optional transform function to apply to each data row
         """
         self.reader = reader
         self.batch_size = batch_size
         self.collate_fn = collate_fn
-        self.transform = transform
 
     def __iter__(self):
         """
@@ -122,9 +120,8 @@ class DataLoader(object):
             # Default collate does not work nicely on namedtuples and treat them as lists
             # Using dict will result in the yielded structures being dicts as well
             row_as_dict = row._asdict()
-            transformed_row = self.transform(row_as_dict) if self.transform else row_as_dict
-            _sanitize_pytorch_types(transformed_row)
-            batch.append(transformed_row)
+            _sanitize_pytorch_types(row_as_dict)
+            batch.append(row_as_dict)
             if len(batch) == self.batch_size:
                 yield self.collate_fn(batch)
                 batch = []

--- a/petastorm/tests/test_pytorch_utils.py
+++ b/petastorm/tests/test_pytorch_utils.py
@@ -15,7 +15,7 @@ from __future__ import division
 
 import numpy as np
 
-from petastorm import make_reader
+from petastorm import make_reader, TransformSpec
 from petastorm.pytorch import DataLoader
 from petastorm.tests.test_common import TestSchema
 
@@ -47,7 +47,8 @@ def test_basic_pytorch_dataloader(synthetic_dataset):
 
 def test_pytorch_dataloader_with_transform_function(synthetic_dataset):
     with DataLoader(make_reader(synthetic_dataset.url, schema_fields=ALL_FIELDS - NULLABLE_FIELDS,
-                                reader_pool_type='dummy'), collate_fn=_noop_collate, transform=_str_to_int) as loader:
+                                reader_pool_type='dummy',
+                                transform_spec=TransformSpec(_str_to_int)), collate_fn=_noop_collate) as loader:
         for item in loader:
             assert len(item) == 1
 

--- a/petastorm/transform.py
+++ b/petastorm/transform.py
@@ -23,8 +23,7 @@ class TransformSpec(object):
         schema transform: pre-transform-schema to post-transform-schema.
 
         ``func`` argument is a callable which takes a row as its parameter and returns a modified row.
-        ``edit_fields`` and ``removed_fields`` define how the schema to which
-        ``edit_fields`` and ``removed_fields`` are define mutation operation performed on the original schema that
+        ``edit_fields`` and ``removed_fields`` define mutating operations performed on the original schema that
         produce a post-transform schema. ``func`` return value must comply to this post-transform schema.
 
         :param func: A callable. The function is called on the worker thread. It takes a dictionary that complies to

--- a/petastorm/workers_pool/exec_in_new_process.py
+++ b/petastorm/workers_pool/exec_in_new_process.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-import pickle
 import subprocess
 import sys
 from tempfile import mkstemp
@@ -59,7 +58,7 @@ if __name__ == '__main__':
         new_process_runnable_file = sys.argv[1]
 
         with open(new_process_runnable_file, 'rb') as f:
-            func, args, kargs = pickle.load(f)
+            func, args, kargs = dill.load(f)
 
         # Don't need the pickle file with the runable. Cleanup.
         os.remove(new_process_runnable_file)


### PR DESCRIPTION
Two commits in this PR:
- Use `dill` in `exec_in_new_process.py` : allows a wider variety of types to be passed to a worker process
- Removing `transform` argument from `DataLoader`: `transform` was a 'toy' implementation which was not useful since it ran on the main thread. Now we have `transform_spec` argument in `make*reader` functions that allow to run a transform on a worker thread
