### PR TITLE
Interpret partition values as correct type from schema when applying predicate

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -544,9 +544,11 @@ class Reader(object):
                 for piece_index, piece in enumerate(row_groups):
                     partition_name, partition_index = piece.partition_keys[0]
                     partition_value = dataset.partitions[0].keys[partition_index]
+
+                    # Convert partition value to correct type per the schema
+                    partition_value = self.schema.fields[partition_name].numpy_dtype(partition_value)
                     if predicate.do_include({partition_name: partition_value}):
                         filtered_row_group_indexes.append(piece_index)
-
                 worker_predicate = None
             else:
                 filtered_row_group_indexes = list(range(len(row_groups)))


### PR DESCRIPTION
## Issue
#280 

## Problem
Currently, if a `Reader` is initialized on a partitioned dataset with a predicate, the partition values will be interpreted as strings during predicate application, which is problematic in cases like `"1234"` where the partition value should be read as an int.

## Solution
- [X] Correctly infer type by obtaining it from the unischema
- [x] Add unit test that generates a partitioned dataset and confirms functionality. 