### PR TITLE
#287 - fix materialize_dataset() serialization error by serializing fs factory

### DIFF
--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -84,7 +84,7 @@ def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_su
     arrow_metadata = dataset.common_metadata or None
 
     with materialize_dataset(spark, dataset_url, schema, use_summary_metadata=use_summary_metadata,
-                             pyarrow_filesystem=fs):
+                             filesystem_factory=resolver.filesystem_factory()):
         if use_summary_metadata:
             # Inside the materialize dataset context we just need to write the metadata file as the schema will
             # be written by the context manager.

--- a/petastorm/tests/test_dataset_metadata.py
+++ b/petastorm/tests/test_dataset_metadata.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
+import pyarrow
+from pyspark.sql import SparkSession
+from pyspark.sql.types import IntegerType
 
-from petastorm.etl.dataset_metadata import get_schema_from_dataset_url
+from petastorm.etl.dataset_metadata import get_schema_from_dataset_url, materialize_dataset
 from petastorm.tests.test_common import TestSchema
+from petastorm.unischema import Unischema, UnischemaField, ScalarCodec, dict_to_spark_row
 
 
 def test_get_schema_from_dataset_url(synthetic_dataset):
@@ -29,3 +34,28 @@ def test_get_schema_from_dataset_url_bogus_url():
 
     with pytest.raises(ValueError):
         get_schema_from_dataset_url('/invalid_url')
+
+
+def test_serialize_filesystem_factory(tmpdir):
+    SimpleSchema = Unischema('SimpleSchema', [
+        UnischemaField('id', np.int32, (), ScalarCodec(IntegerType()), False),
+        UnischemaField('foo', np.int32, (), ScalarCodec(IntegerType()), False),
+    ])
+
+    class BogusFS(pyarrow.LocalFileSystem):
+        def __getstate__(self):
+            raise RuntimeError("can not serialize")
+
+    rows_count = 10
+    output_url = "file://{0}/fs_factory_test".format(tmpdir)
+    rowgroup_size_mb = 256
+    spark = SparkSession.builder.config('spark.driver.memory', '2g').master('local[2]').getOrCreate()
+    sc = spark.sparkContext
+    with materialize_dataset(spark, output_url, SimpleSchema, rowgroup_size_mb, filesystem_factory=BogusFS):
+        rows_rdd = sc.parallelize(range(rows_count))\
+            .map(lambda x: {'id': x, 'foo': x})\
+            .map(lambda x: dict_to_spark_row(SimpleSchema, x))
+
+        spark.createDataFrame(rows_rdd, SimpleSchema.as_spark_schema()) \
+            .write \
+            .parquet(output_url)

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -585,12 +585,12 @@ def test_pass_in_pyarrow_filesystem_to_materialize_dataset(synthetic_dataset, tm
     a_moved_path = tmpdir.join('moved').strpath
     copytree(synthetic_dataset.path, a_moved_path)
 
-    local_fs = pyarrow.LocalFileSystem()
+    local_fs = pyarrow.LocalFileSystem
     os.remove(a_moved_path + '/_common_metadata')
 
     spark = SparkSession.builder.getOrCreate()
 
-    with materialize_dataset(spark, a_moved_path, TestSchema, pyarrow_filesystem=local_fs):
+    with materialize_dataset(spark, a_moved_path, TestSchema, filesystem_factory=local_fs):
         pass
 
     with make_reader('file://{}'.format(a_moved_path), reader_pool_type='dummy') as reader:

--- a/petastorm/tools/copy_dataset.py
+++ b/petastorm/tools/copy_dataset.py
@@ -67,7 +67,8 @@ def copy_dataset(spark, source_url, target_url, field_regex, not_null_fields, ov
         subschema = schema
 
     resolver = FilesystemResolver(target_url, spark.sparkContext._jsc.hadoopConfiguration(), hdfs_driver=hdfs_driver)
-    with materialize_dataset(spark, target_url, subschema, row_group_size_mb, pyarrow_filesystem=resolver.filesystem()):
+    with materialize_dataset(spark, target_url, subschema, row_group_size_mb,
+                             filesystem_factory=resolver.filesystem_factory()):
         data_frame = spark.read \
             .parquet(source_url)
 


### PR DESCRIPTION
## Issue
#287 

## Problem
When using the `materialize_dataset()` context manager, the cleanup steps attempts to write rowgroup metadata to the generated files via `_generate_num_row_groups_per_file()`. This method attempts to serialize `pyarrow_filesystem` object, which works if the spark driver and executors reference the same JVM process (i.e. if they are on the same machine). However, if multiple processes are used, the `pyarrow_filesystem` object will contain invalid references. 

## Solution
Instead of `_generate_num_row_groups_per_file()` serializing the filesystem object, it should serialize a method for recreating the filesystem object on the spark executor, which can then be called to correctly reference files and obtain metadata.