### PR TITLE
Don't read unneeded columns when working with ngrams.

### DIFF
--- a/petastorm/ngram.py
+++ b/petastorm/ngram.py
@@ -280,3 +280,7 @@ class NGram(object):
             current_schema = self.get_schema_at_timestep(schema=schema, timestep=timestamp)
             ngram_as_tuples[timestamp] = current_schema.make_namedtuple(**data_as_dict)
         return ngram_as_tuples
+
+    def get_field_names_at_all_timesteps(self):
+        """Returns a list of fields that are present at least in the one of the time offsets"""
+        return list({field for fields in self._fields.values() for field in fields})

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -423,7 +423,11 @@ class Reader(object):
 
         # Make a schema view (a view is a Unischema containing only a subset of fields
         # Will raise an exception if invalid schema fields are in schema_fields
-        fields = schema_fields if isinstance(schema_fields, collections.Iterable) else None
+        if self.ngram:
+            fields = self.ngram.get_field_names_at_all_timesteps()
+        else:
+            fields = schema_fields if isinstance(schema_fields, collections.Iterable) else None
+
         storage_schema = stored_schema.create_schema_view(fields) if fields else stored_schema
         if transform_spec:
             self.schema = transform_schema(storage_schema, transform_spec)


### PR DESCRIPTION
Fixing a bug that caused all columns of a dataset to be read when `schema_fields=NGram(...)` was used.
Now, we collect all UnischemaField instances that appears in at least one of the time offsets within an NGram and load only corresponding columns.