### PR TITLE
Should not be setting log level explicitly in a module (not main)

### DIFF
--- a/petastorm/etl/rowgroup_indexing.py
+++ b/petastorm/etl/rowgroup_indexing.py
@@ -26,7 +26,6 @@ from petastorm.etl.legacy import depickle_legacy_package_name_compatible
 from petastorm.fs_utils import FilesystemResolver
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 PARALLEL_SLICE_NUM = 2000
 


### PR DESCRIPTION
This interferes with log level being set by a user.

It is responsibility of a particular entry point to decide on the log level policy. When some module changes the level, it makes it impossible to enforce the desired policy .