### PR TITLE
ARROW-1644/1599:  Excludes list inside structs fields from schema inference.

### DIFF
--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -295,6 +295,31 @@ class UnischemaTest(unittest.TestCase):
 
         assert 'Cannot auto-create unischema due to unsupported column type' in str(ex.exception)
 
+    def test_arrow_schema_arrow_1644_list_of_struct(self):
+        arrow_schema = pa.schema([
+            pa.field('id', pa.string()),
+            pa.field('list_of_struct', pa.list_(pa.struct([('a', pa.string()), ('b', pa.int32())])))
+        ])
+
+        mock_dataset = _mock_parquet_dataset([], arrow_schema)
+
+        unischema = Unischema.from_arrow_schema(mock_dataset)
+        assert getattr(unischema, 'id').name == 'id'
+        assert not hasattr(unischema, 'list_of_struct')
+
+    def test_arrow_schema_arrow_1644_list_of_list(self):
+        arrow_schema = pa.schema([
+            pa.field('id', pa.string()),
+            pa.field('list_of_list',
+                     pa.list_(pa.list_(pa.struct([('a', pa.string()), ('b', pa.int32())]))))
+        ])
+
+        mock_dataset = _mock_parquet_dataset([], arrow_schema)
+
+        unischema = Unischema.from_arrow_schema(mock_dataset)
+        assert getattr(unischema, 'id').name == 'id'
+        assert not hasattr(unischema, 'list_of_list')
+
 
 class UnischemaFieldTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Due to this pyarrow bug, we cannot use some fields in our datasets.
However, since these fields are not always mandatory for the use case to be implemented and since data duplication would be too costly, we can afford to ignore it directly when loading the parquet file.
