### PR TITLE
Unischema supports Parquet schema with more than 255 fields

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,265 @@
+Petastorm includes derived work from CPython(https://github.com/python/cpython/blob/3.6/Lib/collections/__init__.py). The derived work includes:
+
+* changes to support more than 255 fields
+** change the __new__ method implementation
+** add a __reduce__ method to make it pickable
+
+* changes to match the pylint 2.7 checker
+** add of warning ``#pylint: disable=W0122`` for the class_definition exec() call
+** adapt the verbose print() call
+
+CPython is under the Python License 2.0:
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC. Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team. In October of the same
+year, the PythonLabs team moved to Digital Creations, which became
+Zope Corporation. In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization
+created specifically to own Python-related Intellectual Property.
+Zope Corporation was a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition). Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+ Release Derived Year Owner GPL-
+ from compatible? (1)
+
+ 0.9.0 thru 1.2 1991-1995 CWI yes
+ 1.3 thru 1.5.2 1.2 1995-1999 CNRI yes
+ 1.6 1.5.2 2000 CNRI no
+ 2.0 1.6 2000 BeOpen.com no
+ 1.6.1 1.6 2001 CNRI yes (2)
+ 2.1 2.0+1.6.1 2001 PSF no
+ 2.0.1 2.0+1.6.1 2001 PSF yes
+ 2.1.1 2.1+2.0.1 2001 PSF yes
+ 2.1.2 2.1.1 2002 PSF yes
+ 2.1.3 2.1.2 2002 PSF yes
+ 2.2 and above 2.1.1 2001-now PSF yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+ the GPL. All Python licenses, unlike the GPL, let you distribute
+ a modified version without making your changes open source. The
+ GPL-compatible licenses make it possible to combine Python with
+ other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+ because its license has a choice of law clause. According to
+ CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+ is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee. This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis. BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions. Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee. This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party. As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee. Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement. This Agreement together with
+Python 1.6.1 may be located on the Internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013. This
+Agreement may also be obtained from a proxy server on the Internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis. CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement. Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee. This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+ ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands. All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/petastorm/namedtuple.py
+++ b/petastorm/namedtuple.py
@@ -1,0 +1,198 @@
+# Only Python 3.x needs a special namedtuple implementation for > 255 values.
+
+from __future__ import print_function
+
+import sys as _sys
+from collections import namedtuple
+from keyword import iskeyword as _iskeyword
+import six
+
+
+if six.PY2:
+    namedtuple_gt_255_fields = namedtuple
+#     Python 3.7 fixes the 255 fields limit.
+elif _sys.version_info[1] < 7:
+    _class_template = """\
+from builtins import property as _property, tuple as _tuple
+from operator import itemgetter as _itemgetter
+from collections import OrderedDict
+from petastorm.namedtuple import _restore_namedtuple_gt_255_fields
+
+
+class {typename}(tuple):
+    '{typename}({arg_list})'
+
+    __slots__ = ()
+
+    _fields = {field_names!r}
+
+    def __new__(_cls, *args, **kwargs):
+        'Create new instance of {typename}({arg_list})'
+        values = []
+        missings = []
+        for index, field in enumerate(_cls._fields):
+            if index < len(args):
+                values.append(args[index])
+                if field in kwargs:
+                    raise TypeError('__new__() got multiple values for argument %r' % field)
+            elif field in kwargs:
+                values.append(kwargs[field])
+            else:
+                values.append(None)
+                missings.append(field)
+
+        count_missings = len(missings)
+        if count_missings > 0:
+            last_missing = ' and %s' % missings[-1] if count_missings > 1 else ''
+            missings = missings[:-1] if count_missings > 1 else missings
+            raise TypeError('__new__() missing %d required positional argument%s: %s%s' %
+                            (count_missings, 's' if count_missings > 1 else '',
+                            ', '.join(missings), last_missing))
+
+        return _tuple.__new__(_cls, values)
+
+    @classmethod
+    def _make(cls, iterable, new=tuple.__new__, len=len):
+        'Make a new {typename} object from a sequence or iterable'
+        result = new(cls, iterable)
+        if len(result) != {num_fields:d}:
+            raise TypeError('Expected {num_fields:d} arguments, got %d' % len(result))
+        return result
+
+    def _replace(_self, **kwds):
+        'Return a new {typename} object replacing specified fields with new values'
+        result = _self._make(map(kwds.pop, {field_names!r}, _self))
+        if kwds:
+            raise ValueError('Got unexpected field names: %r' % list(kwds))
+        return result
+
+    def __repr__(self):
+        'Return a nicely formatted representation string'
+        return self.__class__.__name__ + '({repr_fmt})' % self
+
+    def _asdict(self):
+        'Return a new OrderedDict which maps field names to their values.'
+        return OrderedDict(zip(self._fields, self))
+
+    def __getnewargs__(self):
+        'Return self as a plain tuple. Used by copy and pickle.'
+        return tuple(self)
+
+    def __reduce__(self):
+        'Makes the namedtuple pickable.'
+
+        cls = self.__class__
+        return (_restore_namedtuple_gt_255_fields, (cls.__name__, cls._fields, tuple(self)))
+
+{field_defs}
+"""
+
+    _repr_template = '{name}=%r'
+
+    _field_template = '''\
+    {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
+'''
+
+    def _restore_namedtuple_gt_255_fields(typename, fields, values):
+        """Creates an namedtuple_gt_255_fields objects along based its __reduce__ description.
+
+        The __reduce__ protocol to support pickling requires:
+        - a callable method that returns the pickled object on restore
+        - a tuple of its arguments.
+
+        This function is called by the __reduce__ method of a generated namedtuple_gt_255_fields
+        to recreate the inital object.
+        """
+        return namedtuple_gt_255_fields(typename, fields)(*values)
+
+    def namedtuple_gt_255_fields(typename, field_names, verbose=False, rename=False, module=None):
+        """Returns a new subclass of tuple with named fields.
+        >>> Point = namedtuple2('Point', ['x', 'y'])
+        >>> Point.__doc__                   # docstring for the new class
+        'Point(x, y)'
+        >>> p = Point(11, y=22)             # instantiate with positional args or keywords
+        >>> p[0] + p[1]                     # indexable like a plain tuple
+        33
+        >>> x, y = p                        # unpack like a regular tuple
+        >>> x, y
+        (11, 22)
+        >>> p.x + p.y                       # fields also accessible by name
+        33
+        >>> d = p._asdict()                 # convert to a dictionary
+        >>> d['x']
+        11
+        >>> Point(**d)                      # convert from a dictionary
+        Point(x=11, y=22)
+        >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
+        Point(x=100, y=22)
+        """
+
+        # Validate the field names.  At the user's option, either generate an error
+        # message or automatically replace the field name with a valid name.
+        if isinstance(field_names, str):
+            field_names = field_names.replace(',', ' ').split()
+        field_names = list(map(str, field_names))
+        typename = str(typename)
+        if rename:
+            seen = set()
+            for index, name in enumerate(field_names):
+                if (not name.isidentifier()
+                        or _iskeyword(name)
+                        or name.startswith('_')
+                        or name in seen):
+                    field_names[index] = '_%d' % index
+                seen.add(name)
+        for name in [typename] + field_names:
+            if type(name) is not str:
+                raise TypeError('Type names and field names must be strings')
+            if not name.isidentifier():
+                raise ValueError('Type names and field names must be valid '
+                                 'identifiers: %r' % name)
+            if _iskeyword(name):
+                raise ValueError('Type names and field names cannot be a '
+                                 'keyword: %r' % name)
+        seen = set()
+        for name in field_names:
+            if name.startswith('_') and not rename:
+                raise ValueError('Field names cannot start with an underscore: '
+                                 '%r' % name)
+            if name in seen:
+                raise ValueError('Encountered duplicate field name: %r' % name)
+            seen.add(name)
+
+        # Fill-in the class template
+        class_definition = _class_template.format(
+            typename=typename,
+            field_names=tuple(list(field_names)),
+            num_fields=len(field_names),
+            arg_list=repr(list(field_names)).replace("'", "")[1:-1],
+            repr_fmt=', '.join(_repr_template.format(name=name)
+                               for name in field_names),
+            field_defs='\n'.join(_field_template.format(index=index, name=name)
+                                 for index, name in enumerate(field_names))
+        )
+
+        # Execute the template string in a temporary namespace and support
+        # tracing utilities by setting a value for frame.f_globals['__name__']
+        namespace = dict(__name__='namedtuple_gt_255_fields_%s' % typename)
+        # pylint: disable=W0122
+        exec(class_definition, namespace)
+        result = namespace[typename]
+        result._source = class_definition
+        if verbose:
+            print(result._source)
+
+        # For pickling to work, the __module__ variable needs to be set to the frame
+        # where the named tuple is created.  Bypass this step in environments where
+        # sys._getframe is not defined (Jython for example) or sys._getframe is not
+        # defined for arguments greater than 0 (IronPython), or where the user has
+        # specified a particular module.
+        if module is None:
+            try:
+                module = _sys._getframe(1).f_globals.get('__name__', '__main__')
+            except (AttributeError, ValueError):
+                pass
+        if module is not None:
+            result.__module__ = module
+
+        return result

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import pytest
-import six
 
 from petastorm import make_batch_reader
 
@@ -65,8 +64,6 @@ def test_specify_columns_to_read(scalar_dataset, reader_factory):
 
 
 @pytest.mark.parametrize('reader_factory', _D)
-@pytest.mark.skipif(six.PY3, reason='Python 3 does not support namedtuples with > 255 number of fields. '
-                                    'https://github.com/uber/petastorm/pull/323 will address this issue')
 def test_many_columns_non_petastorm_dataset(many_columns_non_petastorm_dataset, reader_factory):
     """Check if we can read a dataset with huge number of columns (1000 in this case)"""
     with reader_factory(many_columns_non_petastorm_dataset.url) as reader:

--- a/petastorm/tests/test_tf_dataset.py
+++ b/petastorm/tests/test_tf_dataset.py
@@ -18,7 +18,6 @@ from copy import copy
 
 import numpy as np
 import pytest
-import six
 import tensorflow as tf
 
 from petastorm import make_reader, make_batch_reader
@@ -154,8 +153,6 @@ def test_dataset_on_ngram_not_supported(synthetic_dataset, reader_factory):
 
 
 @pytest.mark.forked
-@pytest.mark.skipif(six.PY3, reason='Python 3 does not support namedtuples with > 255 number of fields. '
-                                    'https://github.com/uber/petastorm/pull/323 will address this issue')
 def test_non_petastorm_with_many_colums_with_one_shot_iterator(many_columns_non_petastorm_dataset):
     """Just a bunch of read and compares of all values to the expected values"""
     with make_batch_reader(many_columns_non_petastorm_dataset.url, workers_count=1) as reader:

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -21,7 +21,6 @@ from decimal import Decimal
 
 import numpy as np
 import pytest
-import six
 import tensorflow as tf
 
 from petastorm import make_reader, make_batch_reader, TransformSpec
@@ -296,8 +295,6 @@ def test_simple_read_tensorflow_with_parquet_dataset(scalar_dataset):
 
 
 @pytest.mark.forked
-@pytest.mark.skipif(six.PY3, reason='Python 3 does not support namedtuples with > 255 number of fields. '
-                                    'https://github.com/uber/petastorm/pull/323 will address this issue')
 def test_simple_read_tensorflow_with_non_petastorm_many_columns_dataset(many_columns_non_petastorm_dataset):
     """Read couple of rows. Make sure all tensors have static shape sizes assigned and the data matches reference
     data"""

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -32,6 +32,7 @@ from pyspark.sql.types import StructField, StructType
 from six import string_types
 
 from petastorm.codecs import ScalarCodec
+from petastorm.namedtuple import namedtuple_gt_255_fields
 
 
 def _fields_as_tuple(field):
@@ -95,7 +96,7 @@ class _NamedtupleCache(object):
         sorted_names = list(sorted(field_names))
         key = ' '.join([parent_schema_name] + sorted_names)
         if key not in _NamedtupleCache._store:
-            _NamedtupleCache._store[key] = namedtuple('{}_view'.format(parent_schema_name), sorted_names)
+            _NamedtupleCache._store[key] = namedtuple_gt_255_fields('{}_view'.format(parent_schema_name), sorted_names)
         return _NamedtupleCache._store[key]
 
 

--- a/petastorm/utils.py
+++ b/petastorm/utils.py
@@ -14,9 +14,7 @@
 
 import logging
 import os
-
 import pyarrow
-
 from multiprocessing import Pool
 
 from pyarrow.filesystem import LocalFileSystem


### PR DESCRIPTION
Many of our datasets have more than 255 fields.
This commit provides an alternative namedtuple implementation 'namedtuple2' to support more than 255 fields with the Python 3.6 interpreter.
