### PR TITLE
Make hdfs connect arguments unicode strings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -386,7 +386,10 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+
+# Ignoring distutils because of the conflict with virtualenv as described
+# here: https://github.com/PyCQA/pylint/issues/73
+ignored-modules=distutils
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.


### PR DESCRIPTION
pyarrow==0.12.1 assume hdfs connect arguments are unicode. Make sure we pass unicode.
(tested using python 2/3 and pyarrow 0.12.1 and 0.11.1)