### PR TITLE
Rename `Unischema.name` to `Unischema._name` property to avoid conflict user fields named `name`.

### DIFF
--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -19,6 +19,7 @@ from decimal import Decimal
 
 import numpy as np
 import pyarrow as pa
+import pytest
 from pyspark import Row
 from pyspark.sql.types import StringType, IntegerType, DecimalType, ShortType, LongType
 
@@ -226,7 +227,12 @@ class UnischemaTest(unittest.TestCase):
             UnischemaField('nullable', np.int32, (), ScalarCodec(StringType()), True),
         ])
 
-        self.assertEqual('TestSchema', TestSchema.name)
+        self.assertEqual('TestSchema', TestSchema._name)
+
+    def test_field_name_conflict_with_unischema_attribute(self):
+        # fields is an existing attribute of Unischema
+        with pytest.warns(UserWarning, match='Can not create dynamic property'):
+            Unischema('TestSchema', [UnischemaField('fields', np.int32, (), ScalarCodec(StringType()), True)])
 
     def test_filter_schema_fields_from_url(self):
         TestSchema = Unischema('TestSchema', [

--- a/petastorm/transform.py
+++ b/petastorm/transform.py
@@ -60,4 +60,4 @@ def transform_schema(schema, transform_spec):
                                                 shape=field_to_edit[2], codec=None, nullable=field_to_edit[3])
         fields.append(edited_unischema_field)
 
-    return Unischema(schema.name + '_transformed', fields)
+    return Unischema(schema._name + '_transformed', fields)

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -17,6 +17,7 @@ in several different python libraries. Currently supported are pyspark, tensorfl
 """
 import copy
 import re
+import warnings
 from collections import namedtuple, OrderedDict
 from decimal import Decimal
 
@@ -109,11 +110,15 @@ class Unischema(object):
         :param fields: a list of ``UnischemaField`` instances describing the fields. The order of the fields is
             not important - they are stored sorted by name internally.
         """
-        self._name = name
+        self.__name = name
         self._fields = OrderedDict([(f.name, f) for f in sorted(fields, key=lambda t: t.name)])
         # Generates attributes named by the field names as an access syntax sugar.
         for f in fields:
-            setattr(self, f.name, f)
+            if not hasattr(self, f.name):
+                setattr(self, f.name, f)
+            else:
+                warnings.warn(('Can not create dynamic property {} because it conflicts with an existing property of '
+                               'Unischema').format(f.name))
 
     def create_schema_view(self, fields):
         """Creates a new instance of the schema using a subset of fields.
@@ -152,10 +157,10 @@ class Unischema(object):
             if field.name not in self._fields:
                 raise ValueError('field {} does not belong to the schema {}'.format(field, self))
 
-        return Unischema('{}_view'.format(self._name), view_fields)
+        return Unischema('{}_view'.format(self.__name), view_fields)
 
     def _get_namedtuple(self):
-        return _NamedtupleCache.get(self._name, self._fields.keys())
+        return _NamedtupleCache.get(self.__name, self._fields.keys())
 
     def __str__(self):
         """Represent this as the following form:
@@ -170,15 +175,15 @@ class Unischema(object):
             fields_str += '  {}(\'{}\', {}, {}, {}, {}),\n'.format(type(field).__name__, field.name,
                                                                    field.numpy_dtype.__name__,
                                                                    field.shape, field.codec, field.nullable)
-        return '{}({}, [\n{}])'.format(type(self).__name__, self._name, fields_str)
+        return '{}({}, [\n{}])'.format(type(self).__name__, self.__name, fields_str)
 
     @property
     def fields(self):
         return self._fields
 
     @property
-    def name(self):
-        return self._name
+    def _name(self):
+        return self.__name
 
     def as_spark_schema(self):
         """Returns an object derived from the unischema as spark schema.


### PR DESCRIPTION
"name" is a likely name for a user column. Existing `Unishema.name` attribute conflicts with
dynamically generated attributes. We rename `Unischema.name` into `Unischema._name`. If there
is a conflict between user field and existing attribute, we emit a warning and skip dynamic
attribute creation for that field.
