### PR TITLE
Add an option to warn and ignore unsupported columns

### DIFF
--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -320,6 +320,17 @@ class UnischemaTest(unittest.TestCase):
         assert getattr(unischema, 'id').name == 'id'
         assert not hasattr(unischema, 'list_of_list')
 
+    def test_arrow_schema_convertion_ignore(self):
+        arrow_schema = pa.schema([
+            pa.field('list_of_int', pa.float16()),
+            pa.field('struct', pa.struct([('a', pa.string()), ('b', pa.int32())])),
+        ])
+
+        mock_dataset = _mock_parquet_dataset([], arrow_schema)
+
+        unischema = Unischema.from_arrow_schema(mock_dataset, omit_unsupported_fields=True)
+        assert not hasattr(unischema, 'list_of_int')
+
 
 class UnischemaFieldTest(unittest.TestCase):
     @classmethod

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -227,7 +227,7 @@ class Unischema(object):
         When the warn_only parameter is turned to True, unsupported column types prints only warnings.
 
         :param arrow_schema: :class:`pyarrow.lib.Schema`
-        :param omit_unsupported_fields: ::class: `Boolean`
+        :param omit_unsupported_fields: :class:`Boolean`
         :return: A :class:`Unischema` object.
         """
         meta = parquet_dataset.pieces[0].get_metadata(parquet_dataset.fs.open)


### PR DESCRIPTION
Some Criteo parquet datasets contain unsupported fields.
The current behaviour of Petastorm is to raise a ValueError in the from_arrow_schema()::_numpy_and_codec_from_arrow_type() method when such a field is detected.
This patch introduces an optional argument to print only a warning and ignore the field instead of raising an exception, thus enabling the use of the 'partial' dataset.

