### PR TITLE
Dummy spark codec for skipping encoding/decoding on spark datasets

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -170,7 +170,7 @@ class CompressedNdarrayCodec(DataframeColumnCodec):
         return BinaryType()
 
 
-class DummySparkCodec(DataframeColumnCodec):
+class NoopCodec(DataframeColumnCodec):
     """Uses internal arrow data representation without encoding/decoding"""
 
     def __init__(self, spark_type):

--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -170,6 +170,26 @@ class CompressedNdarrayCodec(DataframeColumnCodec):
         return BinaryType()
 
 
+class DummySparkCodec(DataframeColumnCodec):
+    """Uses internal arrow data representation without encoding/decoding"""
+    
+    def __init__(self, spark_type):
+        """Constructs a codec.
+
+        :param spark_type: an instance of a Type object from :mod:`pyspark.sql.types`
+        """
+        self._spark_type = spark_type
+    
+    def encode(self, unischema_field, value):
+        return value
+
+    def decode(self, unischema_field, value):
+        return value
+
+    def spark_dtype(self):
+        return self._spark_type
+
+
 class ScalarCodec(DataframeColumnCodec):
     """Encodes a scalar into a spark dataframe field."""
 

--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -172,14 +172,14 @@ class CompressedNdarrayCodec(DataframeColumnCodec):
 
 class DummySparkCodec(DataframeColumnCodec):
     """Uses internal arrow data representation without encoding/decoding"""
-    
+
     def __init__(self, spark_type):
         """Constructs a codec.
 
         :param spark_type: an instance of a Type object from :mod:`pyspark.sql.types`
         """
         self._spark_type = spark_type
-    
+
     def encode(self, unischema_field, value):
         return value
 

--- a/petastorm/tests/test_codec_noop.py
+++ b/petastorm/tests/test_codec_noop.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from decimal import Decimal
+
+import numpy as np
+from pyspark.sql.types import StringType, ArrayType
+
+from petastorm.codecs import NoopCodec
+from petastorm.unischema import UnischemaField
+
+
+def test_nested_value():
+    codec = NoopCodec(ArrayType(ArrayType(StringType())))
+    field = UnischemaField(name='field_string', numpy_dtype=np.string_, shape=(None, None), codec=codec, nullable=False)
+    nested_array = [['a', 'b'], ['c'], ['d']]
+    assert codec.decode(field, codec.encode(field, nested_array)) == nested_array


### PR DESCRIPTION
Right now `UnischemaField` expects a codec, however if i have a spark dataset having a column of dtype `array<array<string>>` there is no easy way to create `UnischemaField` for it or at least it's not well documented how to do so. With this codec it's quite easy to define shema field and get nested arrays from petastorm reader later:

```python
from pyspark.sql import types as T

# array<array<string>> spark field
my_field = UnischemaField(
    name, np.unicode_, (None, None),
    NoopCodec(T.ArrayType(T.ArrayType(T.StringType()))),
    False
)
```