### PR TITLE
Fix #333: If integer_object_nulls is set to False, nullable integer fields are return as floats

### DIFF
--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -226,11 +226,13 @@ class PyDictReaderWorker(WorkerBase):
             return filtered_decoded_predicate_rows
 
     def _read_with_shuffle_row_drop(self, piece, pq_file, column_names, shuffle_row_drop_partition):
+        # If integer_object_nulls is set to False, nullable integer fields are return as floats
+        # with nulls translated to nans
         data_frame = piece.read(
             open_file_func=lambda _: pq_file,
             columns=column_names,
             partitions=self._dataset.partitions
-        ).to_pandas()
+        ).to_pandas(integer_object_nulls=True)
 
         num_rows = len(data_frame)
         num_partitions = shuffle_row_drop_partition[1]

--- a/petastorm/reader_impl/row_group_loader.py
+++ b/petastorm/reader_impl/row_group_loader.py
@@ -197,7 +197,7 @@ class RowGroupLoader(object):
             open_file_func=lambda _: parquet_file,
             columns=column_names,
             partitions=self._dataset.partitions
-        ).to_pandas()
+        ).to_pandas(integer_object_nulls=True)
 
         num_rows = len(data_frame)
         num_partitions = shuffle_row_drop_partition[1]

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -50,6 +50,7 @@ TestSchema = Unischema('TestSchema', [
     UnischemaField('matrix_nullable', np.uint16, _DEFAULT_IMAGE_SIZE, NdarrayCodec(), True),
     UnischemaField('sensor_name', np.unicode_, (1,), NdarrayCodec(), False),
     UnischemaField('string_array_nullable', np.unicode_, (None,), NdarrayCodec(), True),
+    UnischemaField('integer_nullable', np.int32, (), ScalarCodec(ShortType()), True),
 ])
 
 
@@ -85,6 +86,7 @@ def _randomize_row(id_num):
         TestSchema.string_array_nullable.name:
             None if id_num % 5 == 0 else np.asarray([], dtype=np.unicode_)
             if id_num % 4 == 0 else np.asarray([str(i + id_num) for i in range(2)], dtype=np.unicode_),
+        TestSchema.integer_nullable.name: None if id_num % 2 else np.int32(id_num),
     }
     return row_dict
 

--- a/petastorm/tests/test_pytorch_dataloader.py
+++ b/petastorm/tests/test_pytorch_dataloader.py
@@ -12,7 +12,7 @@ from petastorm.tests.test_common import TestSchema
 
 BATCHABLE_FIELDS = set(TestSchema.fields.values()) - \
                    {TestSchema.matrix_nullable, TestSchema.string_array_nullable,
-                    TestSchema.matrix_string, TestSchema.empty_matrix_string}
+                    TestSchema.matrix_string, TestSchema.empty_matrix_string, TestSchema.integer_nullable}
 
 # pylint: disable=unnecessary-lambda
 MINIMAL_READER_FLAVOR_FACTORIES = [

--- a/petastorm/tests/test_tf_dataset.py
+++ b/petastorm/tests/test_tf_dataset.py
@@ -28,7 +28,8 @@ from petastorm.tests.test_common import TestSchema
 from petastorm.tf_utils import make_petastorm_dataset
 
 _EXCLUDE_FIELDS = set(TestSchema.fields.values()) \
-                  - {TestSchema.matrix_nullable, TestSchema.string_array_nullable, TestSchema.decimal}
+                  - {TestSchema.matrix_nullable, TestSchema.string_array_nullable, TestSchema.decimal,
+                     TestSchema.integer_nullable}
 
 MINIMAL_READER_FLAVOR_FACTORIES = [
     lambda url, **kwargs: make_reader(url, **_merge_params({'reader_pool_type': 'dummy',

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -32,7 +32,7 @@ from petastorm.tf_utils import _sanitize_field_tf_types, _numpy_to_tf_dtypes, \
 from petastorm.unischema import Unischema, UnischemaField
 
 NON_NULLABLE_FIELDS = set(TestSchema.fields.values()) - \
-                      {TestSchema.matrix_nullable, TestSchema.string_array_nullable}
+                      {TestSchema.matrix_nullable, TestSchema.string_array_nullable, TestSchema.integer_nullable}
 
 
 @contextmanager


### PR DESCRIPTION
The fix is to use appropriate switch in a call to pyarrow table to pandas conversion.