### PR TITLE
Add `Reader.reset()` method.

### DIFF
--- a/petastorm/workers_pool/tests/test_ventilator.py
+++ b/petastorm/workers_pool/tests/test_ventilator.py
@@ -14,8 +14,8 @@
 
 
 import time
-
 import unittest
+
 from petastorm.workers_pool import EmptyResultError
 from petastorm.workers_pool.dummy_pool import DummyPool
 from petastorm.workers_pool.process_pool import ProcessPool
@@ -66,6 +66,50 @@ class TestWorkersPool(unittest.TestCase):
             # After stopping the ventilator queue, we should only get 10 results
             ventilator.stop()
             for _ in range(max_ventilation_size):
+                pool.get_results()
+
+            with self.assertRaises(EmptyResultError):
+                pool.get_results()
+
+            pool.stop()
+            pool.join()
+
+    def test_reset_in_the_middle_of_ventilation(self):
+        """Can not reset ventilator in the middle of ventilation"""
+        for pool in [DummyPool(), ThreadPool(10)]:
+            ventilator = ConcurrentVentilator(ventilate_fn=pool.ventilate,
+                                              items_to_ventilate=[{'item': i} for i in range(100)],
+                                              iterations=None)
+            pool.start(IdentityWorker, ventilator=ventilator)
+
+            # Resetting is supported only when the ventilator has finished
+            with self.assertRaises(NotImplementedError):
+                ventilator.reset()
+
+            pool.stop()
+            pool.join()
+
+    def test_reset_ventilator(self):
+        """Resetting ventilator after all items were ventilated will make it re-ventilate the same items"""
+        items_count = 100
+        for pool in [DummyPool(), ThreadPool(10)]:
+            ventilator = ConcurrentVentilator(ventilate_fn=pool.ventilate,
+                                              items_to_ventilate=[{'item': i} for i in range(items_count)],
+                                              iterations=1)
+            pool.start(IdentityWorker, ventilator=ventilator)
+
+            # Readout all ventilated items
+            for _ in range(items_count):
+                pool.get_results()
+
+            # Should fail reading the next, as all items were read by now
+            with self.assertRaises(EmptyResultError):
+                pool.get_results()
+
+            # Resetting, hence will be read out the items all over again
+            ventilator.reset()
+
+            for _ in range(items_count):
                 pool.get_results()
 
             with self.assertRaises(EmptyResultError):

--- a/petastorm/workers_pool/ventilator.py
+++ b/petastorm/workers_pool/ventilator.py
@@ -97,6 +97,8 @@ class ConcurrentVentilator(Ventilator):
         self._iterations_remaining = iterations
         self._randomize_item_order = randomize_item_order
 
+        self._iterations = iterations
+
         # For the default max ventilation queue size we will use the size of the items to ventilate
         self._max_ventilation_queue_size = max_ventilation_queue_size or len(items_to_ventilate)
         self._ventilation_interval = ventilation_interval
@@ -119,6 +121,17 @@ class ConcurrentVentilator(Ventilator):
     def completed(self):
         assert self._iterations_remaining is None or self._iterations_remaining >= 0
         return self._stop_requested or self._iterations_remaining == 0 or not self._items_to_ventilate
+
+    def reset(self):
+        """Will restart the ventilation from the beginning. Currently, we may do this only if the ventilator has
+        finished ventilating all its items (i.e. ventilator.completed()==True)
+        """
+        if not self.completed():
+            # Might be hard to solve all race conditions, unless no more ventilation is going on.
+            raise NotImplementedError('Reseting ventilator while ventilating is not supported.')
+
+        self._iterations_remaining = self._iterations
+        self.start()
 
     def _ventilate(self):
         while True:


### PR DESCRIPTION
Resets ``Reader`` state and allows to fetch more samples once the ``Reader`` finished reading all epochs,
as specified by the ``num_epochs`` parameter.

Once all samples were read from a reader, an attempt to fetch new sample (e.g. ``next(reader)`` would raise
``StopIterationError``. You can reset the reader to the original state and restart reading samples
calling ``reset()``.

We do not support calling ``reset()`` until all samples were consumed. ``NotImplementedError``
will be raised if a user attempt to do so.