### PR TITLE
Allow native Parquet types to flow freely to the user.

### DIFF
--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -152,9 +152,13 @@ def test_transform_function_new_field(synthetic_dataset, reader_factory):
 def test_transform_function_batched(scalar_dataset):
     def double_float64(sample):
         sample['float64'] *= 2
+        # https://issues.apache.org/jira/browse/ARROW-5161: from_pandas does not support struct fields.
+        # By removing the struct field we make the test pass.
+        del sample['struct']
         return sample
 
-    with make_batch_reader(scalar_dataset.url, transform_spec=TransformSpec(double_float64)) as reader:
+    with make_batch_reader(scalar_dataset.url, transform_spec=TransformSpec(double_float64,
+                                                                            removed_fields=['struct'])) as reader:
         actual = next(reader)
         for actual_id, actual_float64 in zip(actual.id, actual.float64):
             original_sample = next(d for d in scalar_dataset.data if d['id'] == actual_id)
@@ -166,9 +170,13 @@ def test_transform_function_with_predicate_batched(scalar_dataset):
     def double_float64(sample):
         assert all(sample['id'] % 2 == 0)
         sample['float64'] *= 2
+        # https://issues.apache.org/jira/browse/ARROW-5161: from_pandas does not support struct fields.
+        # By removing the struct field we make the test pass.
+        del sample['struct']
         return sample
 
-    with make_batch_reader(scalar_dataset.url, transform_spec=TransformSpec(double_float64),
+    with make_batch_reader(scalar_dataset.url, transform_spec=TransformSpec(double_float64,
+                                                                            removed_fields=['struct']),
                            predicate=in_lambda(['id'], lambda id: id % 2 == 0)) as reader:
         actual = next(reader)
         for actual_id, actual_float64 in zip(actual.id, actual.float64):

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -102,6 +102,15 @@ def _schema_to_tf_dtypes(schema):
     :param schema: The schema.
     :return: List of tensorflow dtypes.
     """
+
+    list_of_dtypes = []
+    for f in schema.fields.values():
+        if f.numpy_dtype is None:
+            raise RuntimeError(('Don\'t know how to map field \'{}\' to a Tensorflow Tensor type. '
+                                'Use make_reader or make_batch_reader \'transform_spec=\' argument to transform this '
+                                'field to a numpy array or a scalar that can be then converted to one of the '
+                                'Tensorflow Tensor types.').format(f.name))
+        list_of_dtypes.append(_numpy_to_tf_dtypes(f.numpy_dtype))
     return [_numpy_to_tf_dtypes(f.numpy_dtype) for f in schema.fields.values()]
 
 


### PR DESCRIPTION
Tensorflow adaptor will now raise a meaningful error message if this parquet/arrow type can not be converted to tf.Tensor.
These non-Tensorflow compatible types maybe converted to tensor compatible types in transform_spec.