### PR TITLE
[WIP] #317 - Allow passing of a username parameter to FileSystemResolver

### DIFF
--- a/examples/hello_world/petastorm_dataset/generate_petastorm_dataset.py
+++ b/examples/hello_world/petastorm_dataset/generate_petastorm_dataset.py
@@ -63,4 +63,5 @@ def generate_petastorm_dataset(output_url='file:///tmp/hello_world_dataset'):
 
 
 if __name__ == '__main__':
-    generate_petastorm_dataset()
+    # TOOD (joshua.goller): Undo this
+    generate_petastorm_dataset("hdfs://ns-silver-prod-irn1/user/joshua.goller/petastorm")

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -50,7 +50,7 @@ class PetastormMetadataGenerationError(Exception):
 
 @contextmanager
 def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_summary_metadata=False,
-                        filesystem_factory=None):
+                        filesystem_factory=None, username=None):
     """
     A Context Manager which handles all the initialization and finalization necessary
     to generate metadata for a petastorm dataset. This should be used around your
@@ -97,7 +97,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_
 
     # After job completes, add the unischema metadata and check for the metadata summary file
     if filesystem_factory is None:
-        resolver = FilesystemResolver(dataset_url, spark.sparkContext._jsc.hadoopConfiguration())
+        resolver = FilesystemResolver(dataset_url, spark.sparkContext._jsc.hadoopConfiguration(), username)
         filesystem_factory = resolver.filesystem_factory()
         dataset_path = resolver.get_dataset_path()
     else:

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -71,8 +71,6 @@ class FilesystemResolver(object):
         elif self._parsed_dataset_url.scheme == 'hdfs':
 
             if hdfs_driver == 'libhdfs3':
-                self.hdfs_username = username
-
                 # libhdfs3 does not do any namenode resolution itself so we do it manually. This is not necessary
                 # if using libhdfs
                 # Obtain singleton and force hadoop config evaluation
@@ -84,12 +82,13 @@ class FilesystemResolver(object):
                     nameservice = self._parsed_dataset_url.netloc.split(':')[0]
                     namenodes = namenode_resolver.resolve_hdfs_name_service(nameservice)
                     if namenodes:
-                        self._filesystem = connector.connect_to_either_namenode(namenodes)
-                        self._filesystem_factory = lambda: connector.connect_to_either_namenode(namenodes)
+                        self._filesystem = connector.connect_to_either_namenode(namenodes, username)
+                        self._filesystem_factory = lambda: connector.connect_to_either_namenode(namenodes, username)
                     if self._filesystem is None:
                         # Case 3a1: That didn't work; try the URL as a namenode host
-                        self._filesystem = connector.hdfs_connect_namenode(self._parsed_dataset_url)
-                        self._filesystem_factory = lambda: connector.hdfs_connect_namenode(self._parsed_dataset_url)
+                        self._filesystem = connector.hdfs_connect_namenode(self._parsed_dataset_url, username)
+                        self._filesystem_factory = lambda: connector.hdfs_connect_namenode(self._parsed_dataset_url,
+                                                                                           username)
                 else:
                     # Case 3b: No netloc, so let's try to connect to default namenode
                     # HdfsNamenodeResolver will raise exception if it fails to connect.

--- a/petastorm/hdfs/namenode.py
+++ b/petastorm/hdfs/namenode.py
@@ -241,7 +241,7 @@ class HdfsConnector(object):
     MAX_NAMENODES = 2
 
     @classmethod
-    def hdfs_connect_namenode(cls, url, driver='libhdfs3'):
+    def hdfs_connect_namenode(cls, url, driver='libhdfs3', username=None):
         """
         Performs HDFS connect in one place, facilitating easy change of driver and test mocking.
 
@@ -259,7 +259,7 @@ class HdfsConnector(object):
         else:
             hostname = six.text_type(url.hostname or 'default')
             driver = six.text_type(driver)
-        return pyarrow.hdfs.connect(hostname, url.port or 8020, driver=driver)
+        return pyarrow.hdfs.connect(hostname, url.port or 8020, driver=driver, user=username)
 
     @classmethod
     def connect_to_either_namenode(cls, list_of_namenodes):

--- a/petastorm/hdfs/namenode.py
+++ b/petastorm/hdfs/namenode.py
@@ -241,7 +241,7 @@ class HdfsConnector(object):
     MAX_NAMENODES = 2
 
     @classmethod
-    def hdfs_connect_namenode(cls, url, driver='libhdfs3', username=None):
+    def hdfs_connect_namenode(cls, url, username=None, driver='libhdfs3'):
         """
         Performs HDFS connect in one place, facilitating easy change of driver and test mocking.
 

--- a/petastorm/tests/test_fs_utils.py
+++ b/petastorm/tests/test_fs_utils.py
@@ -87,6 +87,15 @@ class FilesystemResolverTest(unittest.TestCase):
         self.assertEqual(0, self.mock.connect_attempted(HC.WARP_TURTLE_NN1))
         self.assertEqual(0, self.mock.connect_attempted(HC.DEFAULT_NN))
 
+    def test_hdfs_url_with_nameservice_and_username(self):
+        """ Case 3a, but with username"""
+        suj = FilesystemResolver(HC.WARP_TURTLE_PATH, self._hadoop_configuration, connector=self.mock, username="dr.who")
+        self.assertEqual(MockHdfs, type(suj.filesystem()._hdfs))
+        self.assertEqual(HC.WARP_TURTLE, suj.parsed_dataset_url().netloc)
+        self.assertEqual(1, self.mock.connect_attempted(HC.WARP_TURTLE_NN2))
+        self.assertEqual(0, self.mock.connect_attempted(HC.WARP_TURTLE_NN1))
+        self.assertEqual(0, self.mock.connect_attempted(HC.DEFAULT_NN))
+
     def test_hdfs_url_no_nameservice(self):
         """ Case 3b: HDFS with no nameservice should connect to default namenode."""
         suj = FilesystemResolver('hdfs:///some/path', self._hadoop_configuration, connector=self.mock)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIRED_PACKAGES = [
     'psutil>=4.0.0',
     'pyspark>=2.1.0',
     'pyzmq>=14.0.0',
-    'pyarrow>=0.10',
+    'pyarrow==0.12.1',  # NOTE(joshua.goller): pyarrow 0.13.1 segfaults when connecting to HDFS; use 0.12.1 for now
     'six>=1.5.0',
 ]
 


### PR DESCRIPTION
# Problem
The `FilesystemResolver` class supports connecting to HDFS. However, there is no capability to pass a an HDFS username to the class - therefore, it is very easy to run into permissions issues on created directories; it is not clear if a user who creates a directory will be able to access it later on.

# Solution
Allow passing of a username parameter to `FileSystemResolver` to correct this issue.