### PR TITLE
Multiple index selectors

### DIFF
--- a/petastorm/selectors.py
+++ b/petastorm/selectors.py
@@ -14,6 +14,7 @@
 
 import abc
 import six
+from typing import List
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -47,4 +48,48 @@ class SingleIndexSelector(RowGroupSelectorBase):
         row_groups = set()
         for value in self._values_to_select:
             row_groups |= indexer.get_row_group_indexes(value)
+        return row_groups
+
+
+class IntersectIndexSelector(RowGroupSelectorBase):
+    """
+    Multiple single-field indexers selector.
+    Select row groups containing any of the values in all given selectors.
+    """
+
+    def __init__(self, single_index_selectors: List[SingleIndexSelector]):
+        self._single_index_selectors = single_index_selectors
+
+    def get_index_names(self):
+        index_names = []
+        for single_index_selector in self._single_index_selectors:
+            index_names.append(single_index_selector.get_index_names()[0])
+        return index_names
+
+    def select_row_groups(self, index_dict):
+        row_groups = self._single_index_selectors[0].select_row_groups(index_dict)
+        for single_index_selector in self._single_index_selectors:
+            row_groups &= single_index_selector.select_row_groups(index_dict)
+        return row_groups
+
+
+class UnionIndexSelector(RowGroupSelectorBase):
+    """
+    Multiple single-field indexers selector.
+    Select row groups containing any of the values in at least one selector.
+    """
+
+    def __init__(self, single_index_selectors: List[SingleIndexSelector]):
+        self._single_index_selectors = single_index_selectors
+
+    def get_index_names(self):
+        index_names = []
+        for single_index_selector in self._single_index_selectors:
+            index_names.append(single_index_selector.get_index_names()[0])
+        return index_names
+
+    def select_row_groups(self, index_dict):
+        row_groups = set()
+        for single_index_selector in self._single_index_selectors:
+            row_groups |= single_index_selector.select_row_groups(index_dict)
         return row_groups

--- a/petastorm/selectors.py
+++ b/petastorm/selectors.py
@@ -14,7 +14,6 @@
 
 import abc
 import six
-from typing import List
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -57,7 +56,10 @@ class IntersectIndexSelector(RowGroupSelectorBase):
     Select row groups containing any of the values in all given selectors.
     """
 
-    def __init__(self, single_index_selectors: List[SingleIndexSelector]):
+    def __init__(self, single_index_selectors):
+        """
+        :param single_index_selectors: List of SingleIndexSelector
+        """
         self._single_index_selectors = single_index_selectors
 
     def get_index_names(self):
@@ -79,7 +81,10 @@ class UnionIndexSelector(RowGroupSelectorBase):
     Select row groups containing any of the values in at least one selector.
     """
 
-    def __init__(self, single_index_selectors: List[SingleIndexSelector]):
+    def __init__(self, single_index_selectors):
+        """
+        :param single_index_selectors: List of SingleIndexSelector
+        """
         self._single_index_selectors = single_index_selectors
 
     def get_index_names(self):


### PR DESCRIPTION

It seems that currently `rowgroup_selector` parameter in `make_reader` allows filtering using only a single indexed field. This is limiting, since one might need to filter a dataset according to multiple indexed fields. Predicates can be used in combination with rowgroup_selector to get the desired data, but this approach might require extensive I/O against the data repository.

The code below solves this issue by adding the functionality to filter row groups using multiple indexes with IntersectIndexSelector and UnionIndexSelector.

