### PR TITLE
Guarantee filesystem_factory returned from FilesystemResolver is serializable

### DIFF
--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -85,7 +85,8 @@ class FilesystemResolver(object):
                     if self._filesystem is None:
                         # Case 3a1: That didn't work; try the URL as a namenode host
                         self._filesystem = connector.hdfs_connect_namenode(self._parsed_dataset_url)
-                        self._filesystem_factory = lambda: connector.hdfs_connect_namenode(self._parsed_dataset_url)
+                        self._filesystem_factory = \
+                            lambda url=self._parsed_dataset_url: connector.hdfs_connect_namenode(url)
                 else:
                     # Case 3b: No netloc, so let's try to connect to default namenode
                     # HdfsNamenodeResolver will raise exception if it fails to connect.
@@ -99,8 +100,8 @@ class FilesystemResolver(object):
                         self._filesystem = filesystem
             else:
                 self._filesystem = connector.hdfs_connect_namenode(self._parsed_dataset_url, hdfs_driver)
-                self._filesystem_factory = lambda: connector.hdfs_connect_namenode(
-                    self._parsed_dataset_url, hdfs_driver)
+                self._filesystem_factory = \
+                    lambda url=self._parsed_dataset_url: connector.hdfs_connect_namenode(url, hdfs_driver)
 
         elif self._parsed_dataset_url.scheme == 's3':
             # Case 5
@@ -154,3 +155,8 @@ class FilesystemResolver(object):
         Spark executors.
         """
         return self._filesystem_factory
+
+    def __getstate__(self):
+        raise RuntimeError('Pickling FilesystemResolver is not supported as it may contain some '
+                           'a file-system instance objects that do not support pickling but do not have '
+                           'anti-pickling protection')

--- a/petastorm/hdfs/tests/test_hdfs_namenode.py
+++ b/petastorm/hdfs/tests/test_hdfs_namenode.py
@@ -284,6 +284,11 @@ class MockHdfs(object):
                                '{} namenode failover(s) remaining!'.format(self._n_failovers))
         return True
 
+    def __reduce__(self):
+        raise AssertionError('A connection object can not be pickled. If we try to pickle it, it means '
+                             'it leaks somehow with a closure that holds it and we need to make sure it '
+                             'does not happen.')
+
 
 class MockHdfsConnector(HdfsConnector):
     # static member for static hdfs_connect_namenode to access


### PR DESCRIPTION


We were accidentally capturing FilesystemResolver and its attributes in filesystem_factory returned to the user.
This resulted in failures if attempted to pass the factory to spark executors.

By making FilesystemResolver unpickable we can now cover this accidental pickling by unit tests (which were updated)