### PR TITLE
[WIP] Issue #318: Add libhdfs / libhdfs3 to development container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get -qq install -y \
   python3.6-dev \
   python3.6-venv \
   virtualenv \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 # Temporarily add files needed for env setup.
@@ -43,6 +44,13 @@ RUN virtualenv /petastorm_venv2.7
 RUN python2.7 -m pip install pip --upgrade
 RUN /petastorm_venv2.7/bin/pip2.7 install -e /petastorm/[test,tf,torch,docs,opencv]
 RUN /petastorm_venv2.7/bin/pip2.7 uninstall -y petastorm
+
+# Install Hadoop, set environment
+RUN wget http://archive.apache.org/dist/hadoop/common/hadoop-2.8.1/hadoop-2.8.1.tar.gz -O /root/hadoop-2.8.1.tar.gz
+RUN tar xzf /root/hadoop-2.8.1.tar.gz --directory /root
+RUN echo "export HADOOP_HOME=~/hadoop-2.8.1" >> ~/.bashrc
+RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> ~/.bashrc
+RUN echo "PATH=$PATH:~/hadoop-2.8.1/bin" >> ~/.bashrc
 
 # Clean up
 RUN rm -r /petastorm

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,3 +1,6 @@
+CONTAINER_NAME:=petastorm-test
+IMAGE_NAME:=petastorm
+
 all: rm-image build
 
 # Build the Petastorm container
@@ -8,11 +11,11 @@ all: rm-image build
 build:
 	cd .. && docker build . \
 	-f ./docker/Dockerfile \
-	--tag petastorm
+	--tag $(IMAGE_NAME)
 
 # Create the CI container for Travis use
 push_ci_container:
-	docker tag petastorm:latest selitvin/petastorm_ci:latest
+	docker tag $(IMAGE_NAME):latest selitvin/petastorm_ci:latest
 	echo "$$DOCKER_PASSWORD" | docker login -u "$$DOCKER_USERNAME" --password-stdin
 	docker push selitvin/petastorm_ci:latest
 
@@ -23,18 +26,18 @@ run:
 	docker run \
 	-dt \
 	-v `pwd`/..:/petastorm \
-	--name petastorm \
-	petastorm
+	--name $(CONTAINER_NAME) \
+	$(IMAGE_NAME)
 
 # Create a shell into a running container
 shell:
-	docker exec -it petastorm /bin/bash
+	docker exec -it $(CONTAINER_NAME) /bin/bash
 
 # Stop and remove running containers
 clean:
-	-docker stop petastorm
-	-docker rm petastorm
+	-docker stop $(CONTAINER_NAME)
+	-docker rm $(CONTAINER_NAME)
 
 # Expunge old container image
 rm-image:
-	-docker rmi petastorm
+	-docker rmi $(IMAGE_NAME)


### PR DESCRIPTION
**Problem**
If you want to interface with HDFS in Petastorm, you need to have the proper dependencies installed, specifically the libhdfs or libhdfs3 library. Working on HDFS-related issues from non-Linux work machines can therefore be a problem - I had to manually install this previously so I could work around the issue.

**Solution**
- [x] Install Hadoop / the `libhdfs` library in the Dockerfile.
- [ ] Install `libhdfs3` in the Dockerfile