### PR TITLE
Cleanup at the end of travis build and deploy only for one build matrix configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ python:
   - '2.7'
   - '3.6'
 env:
-  - PYARROW_VERSION=0.10.0 TF_VERSION=1.12
-  - PYARROW_VERSION=0.12.1 TF_VERSION=1.12
+  - PYARROW_VERSION=0.10.0 TF_VERSION=1.12 DEPLOYABLE=0
+  - PYARROW_VERSION=0.12.1 TF_VERSION=1.12 DEPLOYABLE=1
 services:
   - docker
 
@@ -29,6 +29,7 @@ install:
   # installed, we do rerun dependencies installation to refresh ersions of the dependencies
   # on each build if needed
   - docker pull selitvin/petastorm_ci:latest
+  - docker images
 
 before_script:
   # run docker container for an hour. Will execute all docker commands inside this container
@@ -88,6 +89,7 @@ script:
 
 after_success:
   - codecov
+  - $RUN git clean -df
 
 after_failure:
   # Only upon failure, install gdb to process core dump
@@ -111,6 +113,8 @@ deploy:
     on:
       tags: true
       python: 3.6
+      condition: $DEPLOYABLE = 1
+
 
   # Push all python wheels created to Github release
   - provider: releases
@@ -122,3 +126,4 @@ deploy:
     on:
       tags: true
       python: 3.6
+      condition: $DEPLOYABLE = 1


### PR DESCRIPTION
Current hypothesis that travis tries to cleanup after docker build, but has no permissions (since docker writes out *pyc files as root).
Cleaning ourselves would hopefully solve the release failure.