### PR TITLE
Adding the user parameter when pyarrow.hdfs.connect and using spark user when possible 

### DIFF
--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -50,7 +50,7 @@ class PetastormMetadataGenerationError(Exception):
 
 @contextmanager
 def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_summary_metadata=False,
-                        filesystem_factory=None):
+                        filesystem_factory=None, user=None):
     """
     A Context Manager which handles all the initialization and finalization necessary
     to generate metadata for a petastorm dataset. This should be used around your
@@ -89,7 +89,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_
       indexing method. The custom indexing method is more scalable for very large datasets.
     :param pyarrow_filesystem: A pyarrow filesystem object to be used when saving Petastorm specific metadata to the
       Parquet store.
-
+    :param user: String denoting username when connecting to HDFS. None implies login user.
     """
     spark_config = {}
     _init_spark(spark, spark_config, row_group_size_mb, use_summary_metadata)
@@ -97,7 +97,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_
 
     # After job completes, add the unischema metadata and check for the metadata summary file
     if filesystem_factory is None:
-        resolver = FilesystemResolver(dataset_url, spark.sparkContext._jsc.hadoopConfiguration())
+        resolver = FilesystemResolver(dataset_url, spark.sparkContext._jsc.hadoopConfiguration(), user=user)
         filesystem_factory = resolver.filesystem_factory()
         dataset_path = resolver.get_dataset_path()
     else:

--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -45,7 +45,7 @@ spark-submit \\
 
 
 def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_summary_metadata=False,
-                                hdfs_driver='libhdfs3', user=None):
+                                hdfs_driver='libhdfs3'):
     """
     Generates metadata necessary to read a petastorm dataset to an existing dataset.
 
@@ -60,7 +60,8 @@ def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_su
     """
     sc = spark.sparkContext
 
-    resolver = FilesystemResolver(dataset_url, sc._jsc.hadoopConfiguration(), hdfs_driver=hdfs_driver, user=user)
+    resolver = FilesystemResolver(dataset_url, sc._jsc.hadoopConfiguration(), hdfs_driver=hdfs_driver,
+                                  user=spark.sparkContext.sparkUser())
     fs = resolver.filesystem()
     dataset = pq.ParquetDataset(
         resolver.get_dataset_path(),
@@ -85,7 +86,7 @@ def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_su
     arrow_metadata = dataset.common_metadata or None
 
     with materialize_dataset(spark, dataset_url, schema, use_summary_metadata=use_summary_metadata,
-                             filesystem_factory=resolver.filesystem_factory(), user=user):
+                             filesystem_factory=resolver.filesystem_factory()):
         if use_summary_metadata:
             # Inside the materialize dataset context we just need to write the metadata file as the schema will
             # be written by the context manager.
@@ -133,8 +134,6 @@ def _main(args):
     parser.add_argument('--hdfs-driver', type=str, default='libhdfs3',
                         help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
                              'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
-    parser.add_argument('--user', type=str, default=None, required=False,
-                        help='Username given when connecting to hdfs')
     args = parser.parse_args(args)
 
     # Open Spark Session
@@ -148,7 +147,7 @@ def _main(args):
     spark = spark_session.getOrCreate()
 
     generate_petastorm_metadata(spark, args.dataset_url, args.unischema_class, args.use_summary_metadata,
-                                hdfs_driver=args.hdfs_driver, user=args.user)
+                                hdfs_driver=args.hdfs_driver)
 
     # Shut down the spark sessions and context
     spark.stop()

--- a/petastorm/etl/rowgroup_indexing.py
+++ b/petastorm/etl/rowgroup_indexing.py
@@ -34,7 +34,7 @@ ROWGROUPS_INDEX_KEY = b'dataset-toolkit.rowgroups_index.v1'
 PieceInfo = namedtuple('PieceInfo', ['piece_index', 'path', 'row_group', 'partition_keys'])
 
 
-def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libhdfs3', user=None):
+def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libhdfs3'):
     """
     Build index for given list of fields to use for fast rowgroup selection
     :param dataset_url: (str) the url for the dataset (or a path if you would like to use the default hdfs config)
@@ -42,7 +42,6 @@ def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libh
     :param indexers: list of objects to build row groups indexes. Should support RowGroupIndexerBase interface
     :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
     libhdfs (java through JNI) or libhdfs3 (C++)
-    :param user: String denoting username when connecting to HDFS. None implies login user.
     :return: None, upon successful completion the rowgroup predicates will be saved to _metadata file
     """
 
@@ -51,7 +50,7 @@ def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libh
 
     # Create pyarrow file system
     resolver = FilesystemResolver(dataset_url, spark_context._jsc.hadoopConfiguration(),
-                                  hdfs_driver=hdfs_driver, user=user)
+                                  hdfs_driver=hdfs_driver, user=sparkContext.sparkUser())
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
                                 validate_schema=False)
 

--- a/petastorm/etl/rowgroup_indexing.py
+++ b/petastorm/etl/rowgroup_indexing.py
@@ -50,7 +50,7 @@ def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libh
 
     # Create pyarrow file system
     resolver = FilesystemResolver(dataset_url, spark_context._jsc.hadoopConfiguration(),
-                                  hdfs_driver=hdfs_driver, user=sparkContext.sparkUser())
+                                  hdfs_driver=hdfs_driver, user=spark_context.sparkUser())
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
                                 validate_schema=False)
 

--- a/petastorm/etl/rowgroup_indexing.py
+++ b/petastorm/etl/rowgroup_indexing.py
@@ -34,7 +34,7 @@ ROWGROUPS_INDEX_KEY = b'dataset-toolkit.rowgroups_index.v1'
 PieceInfo = namedtuple('PieceInfo', ['piece_index', 'path', 'row_group', 'partition_keys'])
 
 
-def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libhdfs3'):
+def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libhdfs3', user=None):
     """
     Build index for given list of fields to use for fast rowgroup selection
     :param dataset_url: (str) the url for the dataset (or a path if you would like to use the default hdfs config)
@@ -42,6 +42,7 @@ def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libh
     :param indexers: list of objects to build row groups indexes. Should support RowGroupIndexerBase interface
     :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
     libhdfs (java through JNI) or libhdfs3 (C++)
+    :param user: String denoting username when connecting to HDFS. None implies login user.
     :return: None, upon successful completion the rowgroup predicates will be saved to _metadata file
     """
 
@@ -49,7 +50,8 @@ def build_rowgroup_index(dataset_url, spark_context, indexers, hdfs_driver='libh
         dataset_url = dataset_url[:-1]
 
     # Create pyarrow file system
-    resolver = FilesystemResolver(dataset_url, spark_context._jsc.hadoopConfiguration(), hdfs_driver=hdfs_driver)
+    resolver = FilesystemResolver(dataset_url, spark_context._jsc.hadoopConfiguration(),
+                                  hdfs_driver=hdfs_driver, user=user)
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
                                 validate_schema=False)
 

--- a/petastorm/hdfs/namenode.py
+++ b/petastorm/hdfs/namenode.py
@@ -210,29 +210,32 @@ def failover_all_class_methods(decorator):
 
 @failover_all_class_methods(namenode_failover)
 class HAHdfsClient(HadoopFileSystem):
-    def __init__(self, connector_cls, list_of_namenodes):
+    def __init__(self, connector_cls, list_of_namenodes, user=None):
         """
         Attempt HDFS connection operation, storing the hdfs object for intercepted calls.
 
         :param connector_cls: HdfsConnector class, so connector logic resides in one place, and
             also facilitates testing.
         :param list_of_namenodes: List of name nodes to failover, cached to enable un-/pickling
+        :param user: String denoting username when connecting to HDFS. None implies login user.
+        :return: None
         """
         # Use protected attribute to prevent mistaken decorator application
         self._connector_cls = connector_cls
         self._list_of_namenodes = list_of_namenodes
+        self._user = user
         # Ensure that a retry will attempt a different name node in the list
         self._index_of_nn = -1
         self._do_connect()
 
     def __reduce__(self):
         """ Returns object state for pickling. """
-        return self.__class__, (self._connector_cls, self._list_of_namenodes)
+        return self.__class__, (self._connector_cls, self._list_of_namenodes, self._user)
 
     def _do_connect(self):
         """ Makes a new connection attempt, caching the new namenode index and HDFS connection. """
         self._index_of_nn, self._hdfs = \
-            self._connector_cls._try_next_namenode(self._index_of_nn, self._list_of_namenodes)
+            self._connector_cls._try_next_namenode(self._index_of_nn, self._list_of_namenodes, user=self._user)
 
 
 class HdfsConnector(object):
@@ -241,12 +244,13 @@ class HdfsConnector(object):
     MAX_NAMENODES = 2
 
     @classmethod
-    def hdfs_connect_namenode(cls, url, driver='libhdfs3'):
+    def hdfs_connect_namenode(cls, url, driver='libhdfs3', user=None):
         """
         Performs HDFS connect in one place, facilitating easy change of driver and test mocking.
 
         :param url: An parsed URL object to the HDFS end point
         :param driver: An optional driver identifier
+        :param user: String denoting username when connecting to HDFS. None implies login user.
         :return: Pyarrow HDFS connection object.
         """
 
@@ -259,10 +263,10 @@ class HdfsConnector(object):
         else:
             hostname = six.text_type(url.hostname or 'default')
             driver = six.text_type(driver)
-        return pyarrow.hdfs.connect(hostname, url.port or 8020, driver=driver)
+        return pyarrow.hdfs.connect(hostname, url.port or 8020, driver=driver, user=user)
 
     @classmethod
-    def connect_to_either_namenode(cls, list_of_namenodes):
+    def connect_to_either_namenode(cls, list_of_namenodes, user=None):
         """
         Returns a wrapper HadoopFileSystem "high-availability client" object that enables
         name node failover.
@@ -270,21 +274,23 @@ class HdfsConnector(object):
         Raises a HdfsConnectError if no successful connection can be established.
 
         :param list_of_namenodes: a required list of name node URLs to connect to.
+        :param user: String denoting username when connecting to HDFS. None implies login user.
         :return: the wrapped HDFS connection object
         """
         assert list_of_namenodes is not None and len(list_of_namenodes) <= cls.MAX_NAMENODES, \
             "Must supply a list of namenodes, but HDFS only supports up to {} namenode URLs" \
             .format(cls.MAX_NAMENODES)
-        return HAHdfsClient(cls, list_of_namenodes)
+        return HAHdfsClient(cls, list_of_namenodes, user=user)
 
     @classmethod
-    def _try_next_namenode(cls, index_of_nn, list_of_namenodes):
+    def _try_next_namenode(cls, index_of_nn, list_of_namenodes, user=None):
         """
         Instead of returning an inline function, this protected class method implements the
         failover logic: circling between namenodes using the supplied index as the last
         index into the name nodes list.
 
         :param list_of_namenodes: a required list of name node URLs to connect to.
+        :param user: String denoting username when connecting to HDFS. None implies login user.
         :return: a tuple of (new index into list, actual pyarrow HDFS connection object), or raise
                 a HdfsConnectError if no successful connection can be established.
         """
@@ -297,7 +303,7 @@ class HdfsConnector(object):
                 host = list_of_namenodes[idx]
                 try:
                     return idx, \
-                        cls.hdfs_connect_namenode(urlparse('hdfs://' + str(host or 'default')))
+                        cls.hdfs_connect_namenode(urlparse('hdfs://' + str(host or 'default')), user=user)
                 except ArrowIOError:
                     # This is an expected error if the namenode we are trying to connect to is
                     # not the active one

--- a/petastorm/tools/copy_dataset.py
+++ b/petastorm/tools/copy_dataset.py
@@ -32,7 +32,7 @@ from petastorm.fs_utils import FilesystemResolver
 
 
 def copy_dataset(spark, source_url, target_url, field_regex, not_null_fields, overwrite_output, partitions_count,
-                 row_group_size_mb, hdfs_driver='libhdfs3', user=None):
+                 row_group_size_mb, hdfs_driver='libhdfs3'):
     """
     Creates a copy of a dataset. A new dataset will optionally contain a subset of columns. Rows that have NULL
     values in fields defined by ``not_null_fields`` argument are filtered out.
@@ -68,9 +68,9 @@ def copy_dataset(spark, source_url, target_url, field_regex, not_null_fields, ov
         subschema = schema
 
     resolver = FilesystemResolver(target_url, spark.sparkContext._jsc.hadoopConfiguration(),
-                                  hdfs_driver=hdfs_driver, user=user)
+                                  hdfs_driver=hdfs_driver, user=spark.sparkContext.sparkUser())
     with materialize_dataset(spark, target_url, subschema, row_group_size_mb,
-                             filesystem_factory=resolver.filesystem_factory(), user=user):
+                             filesystem_factory=resolver.filesystem_factory()):
         data_frame = spark.read \
             .parquet(source_url)
 
@@ -121,8 +121,6 @@ def args_parser():
     parser.add_argument('--hdfs-driver', type=str, default='libhdfs3',
                         help='A string denoting the hdfs driver to use (if using a dataset on hdfs). '
                              'Current choices are libhdfs (java through JNI) or libhdfs3 (C++)')
-    parser.add_argument('--user', type=str, default=None, required=False,
-                        help='Username given when connecting to hdfs')
 
     add_configure_spark_arguments(parser)
 
@@ -142,7 +140,7 @@ def _main(sys_argv):
         .getOrCreate()
 
     copy_dataset(spark, args.source_url, args.target_url, args.field_regex, args.not_null_fields, args.overwrite_output,
-                 args.partition_count, args.row_group_size_mb, hdfs_driver=args.hdfs_driver, user=args.user)
+                 args.partition_count, args.row_group_size_mb, hdfs_driver=args.hdfs_driver)
 
     spark.stop()
 


### PR DESCRIPTION
User is added as optional parameters for filesystem resolver.
Various entry points for file system resolver (materialize dataset, row group indexer, etc) provide the spark user name to filesystem resolver. Usually the spark user name is gotten from HADOOP_USER_NAME environment variable 

