### PR TITLE
Reduce the size of a rowgroup for mnist example.

### DIFF
--- a/examples/mnist/generate_petastorm_mnist.py
+++ b/examples/mnist/generate_petastorm_mnist.py
@@ -109,7 +109,9 @@ def mnist_data_to_petastorm_dataset(download_dir, output_url, spark_master=None,
     # The MNIST data is small enough to do everything here in Python
     for dset, data in mnist_data.items():
         dset_output_url = '{}/{}'.format(output_url, dset)
-        with materialize_dataset(spark, dset_output_url, MnistSchema):
+        # Using row_group_size_mb=1 to avoid having just a single rowgroup in this example. In a real store, the value
+        # should be similar to an HDFS block size.
+        with materialize_dataset(spark, dset_output_url, MnistSchema, row_group_size_mb=1):
             # List of [(idx, image, digit), ...]
             # where image is shaped as a 28x28 numpy matrix
             idx_image_digit_list = map(lambda idx_image_digit: {


### PR DESCRIPTION
Default row-group size is 256MB. We end up having just a single rowgroup of 60K rows. It is really awkward to read from such a dataset since all 60K images need to be decoded before user gets a single row.
With smaller rowgroup size, a user gets first samples right away making it easier to work with the code.