### PR TITLE
Cast int to string in Runtime error (ArrowReaderWorker)

### DIFF
--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -61,9 +61,10 @@ class ArrowReaderWorkerResultsQueueReader(object):
                     try:
                         result_dict[column.name] = np.vstack(list_of_lists.tolist())
                     except ValueError:
-                        raise RuntimeError("""Length of all values in column '%s' are expected to be the same length.
-                                           Got the following set of lengths: '%s'""" %
-                                           (column.name, ', '.join({str(value.shape[0]) for value in list_of_lists})))
+                        raise RuntimeError('Length of all values in column \'{}\' are expected to be the same length. ' 
+                                           'Got the following set of lengths: {}'
+                                           .format(column.name,
+                                                   ', '.join(str(value.shape[0]) for value in list_of_lists)))
                 else:
                     result_dict[column.name] = column_as_pandas
 

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -62,7 +62,7 @@ class ArrowReaderWorkerResultsQueueReader(object):
                         result_dict[column.name] = np.vstack(list_of_lists.tolist())
                     except ValueError:
                         raise RuntimeError('Length of all values in column \'{}\' are expected to be the same length. ' 
-                                           'Got the following set of lengths: {}'
+                                           'Got the following set of lengths: \'{}\''
                                            .format(column.name,
                                                    ', '.join(str(value.shape[0]) for value in list_of_lists)))
                 else:

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -61,7 +61,7 @@ class ArrowReaderWorkerResultsQueueReader(object):
                     try:
                         result_dict[column.name] = np.vstack(list_of_lists.tolist())
                     except ValueError:
-                        raise RuntimeError('Length of all values in column \'{}\' are expected to be the same length. ' 
+                        raise RuntimeError('Length of all values in column \'{}\' are expected to be the same length. '
                                            'Got the following set of lengths: \'{}\''
                                            .format(column.name,
                                                    ', '.join(str(value.shape[0]) for value in list_of_lists)))

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -61,10 +61,9 @@ class ArrowReaderWorkerResultsQueueReader(object):
                     try:
                         result_dict[column.name] = np.vstack(list_of_lists.tolist())
                     except ValueError:
-                        raise RuntimeError('Length of all values in column \'%s\' are expected to be the same length. '
-                                           'Got the following set of lengths: \'%s\'',
-                                           column.name,
-                                           ', '.join({value.shape[0] for value in list_of_lists}))
+                        raise RuntimeError("""Length of all values in column '%s' are expected to be the same length.
+                                           Got the following set of lengths: '%s'""" %
+                                           (column.name, ', '.join({str(value.shape[0]) for value in list_of_lists})))
                 else:
                     result_dict[column.name] = column_as_pandas
 


### PR DESCRIPTION
In ArrowReaderWorker, when trying to load a column of list type, where list is of variable length an error needs to be thrown. This error is defined here.

However the error fails while printing

Instead of
`', '.join({values.shape[0] for value in ....})`

It should be
`', '.join({str(values.shape[0]) for value in ....})`