### PR TITLE
Make 'codec' and 'nullable' optional UnischemaField arguments

### DIFF
--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -22,8 +22,8 @@ import numpy as np
 import pytz
 from pyspark import Row
 from pyspark.sql import SparkSession
-from pyspark.sql.types import StringType, ShortType, LongType, DecimalType, DoubleType, BooleanType, StructField, \
-    IntegerType, StructType, DateType, TimestampType, ArrayType
+from pyspark.sql.types import StringType, DecimalType, DoubleType, StructField, \
+    IntegerType, StructType, DateType, TimestampType, ArrayType, ShortType
 
 from petastorm.codecs import CompressedImageCodec, NdarrayCodec, \
     ScalarCodec
@@ -35,12 +35,12 @@ from petastorm.unischema import Unischema, UnischemaField, dict_to_spark_row
 _DEFAULT_IMAGE_SIZE = (32, 16, 3)
 
 TestSchema = Unischema('TestSchema', [
-    UnischemaField('partition_key', np.unicode_, (), ScalarCodec(StringType()), False),
-    UnischemaField('id', np.int64, (), ScalarCodec(LongType()), False),
-    UnischemaField('id2', np.int32, (), ScalarCodec(ShortType()), False),
-    UnischemaField('id_float', np.float64, (), ScalarCodec(DoubleType()), False),
-    UnischemaField('id_odd', np.bool_, (), ScalarCodec(BooleanType()), False),
-    UnischemaField('python_primitive_uint8', np.uint8, (), ScalarCodec(ShortType()), False),
+    UnischemaField('partition_key', np.unicode_, ()),
+    UnischemaField('id', np.int64, ()),
+    UnischemaField('id2', np.int32, (), ScalarCodec(ShortType()), False),  # Explicit scalar codec in some scalar fields
+    UnischemaField('id_float', np.float64, ()),
+    UnischemaField('id_odd', np.bool_, ()),
+    UnischemaField('python_primitive_uint8', np.uint8, ()),
     UnischemaField('image_png', np.uint8, _DEFAULT_IMAGE_SIZE, CompressedImageCodec('png'), False),
     UnischemaField('matrix', np.float32, _DEFAULT_IMAGE_SIZE, NdarrayCodec(), False),
     UnischemaField('decimal', Decimal, (), ScalarCodec(DecimalType(10, 9)), False),
@@ -51,7 +51,7 @@ TestSchema = Unischema('TestSchema', [
     UnischemaField('matrix_nullable', np.uint16, _DEFAULT_IMAGE_SIZE, NdarrayCodec(), True),
     UnischemaField('sensor_name', np.unicode_, (1,), NdarrayCodec(), False),
     UnischemaField('string_array_nullable', np.unicode_, (None,), NdarrayCodec(), True),
-    UnischemaField('integer_nullable', np.int32, (), ScalarCodec(ShortType()), True),
+    UnischemaField('integer_nullable', np.int32, (), nullable=True),
 ])
 
 
@@ -79,8 +79,8 @@ def _randomize_row(id_num):
         TestSchema.image_png.name: np.random.randint(0, 255, _DEFAULT_IMAGE_SIZE).astype(np.uint8),
         TestSchema.matrix.name: np.random.random(size=_DEFAULT_IMAGE_SIZE).astype(np.float32),
         TestSchema.decimal.name: Decimal(np.random.randint(0, 255) / Decimal(100)),
-        TestSchema.matrix_uint16.name: np.random.randint(0, 2**16 - 1, _DEFAULT_IMAGE_SIZE).astype(np.uint16),
-        TestSchema.matrix_uint32.name: np.random.randint(0, 2**32 - 1, _DEFAULT_IMAGE_SIZE).astype(np.uint32),
+        TestSchema.matrix_uint16.name: np.random.randint(0, 2 ** 16 - 1, _DEFAULT_IMAGE_SIZE).astype(np.uint16),
+        TestSchema.matrix_uint32.name: np.random.randint(0, 2 ** 32 - 1, _DEFAULT_IMAGE_SIZE).astype(np.uint32),
         TestSchema.matrix_string.name: np.asarray(_random_binary_string_matrix(2, 3, 10)).astype(np.bytes_),
         TestSchema.empty_matrix_string.name: np.asarray([], dtype=np.string_),
         TestSchema.matrix_nullable.name: None,

--- a/petastorm/tests/test_decode_row.py
+++ b/petastorm/tests/test_decode_row.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from decimal import Decimal
 
 import numpy as np
 import pytest
+from pyspark.sql.types import DoubleType
 
-from petastorm.codecs import NdarrayCodec
+from petastorm.codecs import NdarrayCodec, ScalarCodec
 from petastorm.unischema import UnischemaField, Unischema
 from petastorm.utils import decode_row, DecodeFieldError
 
@@ -39,3 +41,50 @@ def test_can_not_decode():
 
     with pytest.raises(DecodeFieldError, match='matrix'):
         decode_row(row, MatrixSchema)
+
+
+def test_decode_numpy_scalar_when_codec_is_none():
+    """Decoding a row that has a field with the codec set to None. The type should be deduced automatically
+    from UnischemaField's numpy_dtype attribute"""
+
+    MatrixSchema = Unischema('TestSchema', [UnischemaField('scalar', np.float64, ())])
+    row = {'scalar': 42.0}
+    decoded_value = decode_row(row, MatrixSchema)['scalar']
+    assert decoded_value == 42
+    assert isinstance(decoded_value, np.float64)
+
+
+def test_decode_decimal_scalar_when_codec_is_none():
+    """Decoding a row that has a field with the codec set to None. The type should be deduced automatically
+    from UnischemaField's numpy_dtype attribute if the type is either a numpy scalar or a Decimal"""
+
+    MatrixSchema = Unischema('TestSchema', [UnischemaField('scalar', Decimal, ())])
+
+    row = {'scalar': '123.45'}
+    decoded_value = decode_row(row, MatrixSchema)['scalar']
+    assert decoded_value == Decimal('123.45')
+    assert isinstance(decoded_value, Decimal)
+
+    row = {'scalar': Decimal('123.45')}
+    decoded_value = decode_row(row, MatrixSchema)['scalar']
+    assert decoded_value == Decimal('123.45')
+    assert isinstance(decoded_value, Decimal)
+
+
+def test_decode_numpy_scalar_with_explicit_scalar_codec():
+    """Decoding a row that has a field with the codec set explicitly"""
+
+    MatrixSchema = Unischema('TestSchema', [UnischemaField('scalar', np.float64, (), ScalarCodec(DoubleType()), False)])
+    row = {'scalar': 42.0}
+    decoded_value = decode_row(row, MatrixSchema)['scalar']
+    assert decoded_value == 42
+    assert isinstance(decoded_value, np.float64)
+
+
+def test_decode_numpy_scalar_with_unknown_dtype():
+    """If numpy_dtype is None, then the value is not decoded, just passed through."""
+
+    MatrixSchema = Unischema('TestSchema', [UnischemaField('scalar', None, ())])
+    row = {'scalar': [4, 2]}
+    decoded_value = decode_row(row, MatrixSchema)['scalar']
+    assert decoded_value == [4, 2]

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -498,12 +498,10 @@ def test_invalid_schema_field(synthetic_dataset, reader_factory):
         UnischemaField('bogus_key', np.int32, (), ScalarCodec(ShortType()), False)])
 
     expected_values = {'bogus_key': 11, 'id': 1}
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='bogus_key'):
         reader_factory(synthetic_dataset.url, schema_fields=BogusSchema.fields.values(),
                        shuffle_row_groups=False,
                        predicate=EqualPredicate(expected_values))
-
-    assert 'bogus_key' in str(e)
 
 
 @pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES)


### PR DESCRIPTION
The goal is twofold:
- Spare users' effort of defining codec attribute for fields that are scalars and we can easily decode/encode the values ourselves.
- Make it possible for a user to skip the encoding/decoding mechanism (this is an experimental feature at the moment)

If no codec is specified, we try to deduce spark type from `UnischemaField`''s `numpy_dtype` attribute when possible. If `numpy_dtype` is not set or different from a numpy scalar or a `Decimal`, we just pass it through.
 