### PR TITLE
allow NdarrayCodec.decode to pass through ndarrays

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -136,6 +136,8 @@ class NdarrayCodec(DataframeColumnCodec):
         return bytearray(memfile.getvalue())
 
     def decode(self, unischema_field, value):
+        if type(value) is np.ndarray:
+            return value
         memfile = BytesIO(value)
         return np.load(memfile)
 
@@ -170,6 +172,8 @@ class CompressedNdarrayCodec(DataframeColumnCodec):
         return bytearray(memfile.getvalue())
 
     def decode(self, unischema_field, value):
+        if type(value) is np.ndarray:
+            return value
         memfile = BytesIO(value)
         return np.load(memfile)['arr']
 


### PR DESCRIPTION
We have a workflow where we had a dataset that was not encoded with NDArrayCodec, but we were decoding using it, essentially passing an ndarray through directly.  Was wondering if it is worthwhile to allow this behavior.  It's also possible there is another way to do this that we didn't detect.