### PR TITLE
Raise an error if a user tries to read from a reader after it was stopped

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -354,7 +354,7 @@ single-line-if-stmt=no
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
+contextmanager-decorators=contextlib.contextmanager,tensorflow.python.util.tf_contextlib.contextmanager
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -778,3 +778,20 @@ def test_multithreaded_reads(synthetic_dataset):
             results = [f.result() for f in futures]
             assert len(results) == len(synthetic_dataset.data)
             assert set(r.id for r in results) == set(d['id'] for d in synthetic_dataset.data)
+
+
+def test_should_fail_if_reading_out_of_context_manager(synthetic_dataset):
+    with make_reader(synthetic_dataset.url, workers_count=1) as reader:
+        next(reader)
+
+    with pytest.raises(RuntimeError, match='Trying to read a sample.*'):
+        next(reader)
+
+
+def test_should_fail_if_reading_after_stop(synthetic_dataset):
+    reader = make_reader(synthetic_dataset.url, workers_count=1)
+    next(reader)
+    reader.stop()
+
+    with pytest.raises(RuntimeError, match='Trying to read a sample.*'):
+        next(reader)

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -120,13 +120,13 @@ def _read_from_tf_tensors(synthetic_dataset, count, shuffling_queue_capacity, mi
 
     schema_fields = (NON_NULLABLE_FIELDS if ngram is None else ngram)
 
-    with make_reader(schema_fields=schema_fields, dataset_url=synthetic_dataset.url, reader_pool_type='dummy',
-                     shuffle_row_groups=False) as reader:
-        row_tensors = tf_tensors(reader, shuffling_queue_capacity=shuffling_queue_capacity,
-                                 min_after_dequeue=min_after_dequeue)
-
-        with _tf_session() as sess:
-            rows_data = [sess.run(row_tensors) for _ in range(count)]
+    with tf.Graph().as_default():
+        with make_reader(schema_fields=schema_fields, dataset_url=synthetic_dataset.url, reader_pool_type='dummy',
+                         shuffle_row_groups=False) as reader:
+            row_tensors = tf_tensors(reader, shuffling_queue_capacity=shuffling_queue_capacity,
+                                     min_after_dequeue=min_after_dequeue)
+            with _tf_session() as sess:
+                rows_data = [sess.run(row_tensors) for _ in range(count)]
 
     return rows_data, row_tensors
 

--- a/petastorm/tests/test_weighted_sampling_reader.py
+++ b/petastorm/tests/test_weighted_sampling_reader.py
@@ -103,11 +103,12 @@ def test_with_tf_tensors(synthetic_dataset):
     readers = [make_reader(synthetic_dataset.url, schema_fields=fields_to_read, workers_count=1),
                make_reader(synthetic_dataset.url, schema_fields=fields_to_read, workers_count=1)]
 
-    with WeightedSamplingReader(readers, [0.5, 0.5]) as mixer:
-        mixed_tensors = tf_tensors(mixer)
+    with tf.Graph().as_default():
+        with WeightedSamplingReader(readers, [0.5, 0.5]) as mixer:
+            mixed_tensors = tf_tensors(mixer)
 
-    with tf.Session() as sess:
-        sess.run(mixed_tensors)
+            with tf.Session() as sess:
+                sess.run(mixed_tensors)
 
 
 def test_schema_mismatch(synthetic_dataset):
@@ -135,10 +136,10 @@ def test_ngram_mix(synthetic_dataset):
     with WeightedSamplingReader(readers, [0.5, 0.5]) as mixer:
         mixed_tensors = tf_tensors(mixer)
 
-    with tf.Session() as sess:
-        for _ in range(10):
-            actual = sess.run(mixed_tensors)
-            assert set(actual.keys()) == {-1, 0}
+        with tf.Session() as sess:
+            for _ in range(10):
+                actual = sess.run(mixed_tensors)
+                assert set(actual.keys()) == {-1, 0}
 
 
 def test_ngram_mismsatch(synthetic_dataset):


### PR DESCRIPTION
Encountered this issue in #432 and #396. User tried reading after their context manager
has exited, which resulted in unexpected behavior.