### PR TITLE
Fixups that simplify working with transforms and WeightedSamplingReader

### DIFF
--- a/petastorm/__init__.py
+++ b/petastorm/__init__.py
@@ -16,4 +16,4 @@ from petastorm.errors import NoDataAvailableError  # noqa: F401
 from petastorm.reader import make_reader, make_batch_reader  # noqa: F401
 from petastorm.transform import TransformSpec  # noqa: F401
 
-__version__ = '0.7.7rc3'
+__version__ = '0.7.7rc4'

--- a/petastorm/ngram.py
+++ b/petastorm/ngram.py
@@ -324,3 +324,16 @@ class NGram(object):
         converted_fields = unischema_field_objects + match_unischema_fields(unischema, regex_patterns)
 
         return converted_fields
+
+    def __eq__(self, other):
+        if set(self.fields.keys()) != set(other.fields.keys()):
+            return False
+
+        for key in self.fields.keys():
+            if set(self.fields[key]) != set(other.fields[key]):
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self == other

--- a/petastorm/tests/test_ngram.py
+++ b/petastorm/tests/test_ngram.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from petastorm.ngram import NGram
+from petastorm.unischema import UnischemaField, Unischema
+
+TestSchema = Unischema('TestSchema', [
+    UnischemaField('string', np.unicode_, (), None, False),
+    UnischemaField('int', np.int32, (), None, False),
+    UnischemaField('double', np.float64, (), None, False),
+])
+
+
+def test_eq():
+    ngram1 = NGram({-1: [TestSchema.string], 0: [TestSchema.int]}, delta_threshold=1, timestamp_field=TestSchema.int)
+    ngram2 = NGram({-1: [TestSchema.string], 0: [TestSchema.int]}, delta_threshold=1, timestamp_field=TestSchema.int)
+
+    assert ngram1 == ngram1
+    assert ngram1 == ngram2
+
+    assert not ngram1 != ngram1
+    assert not ngram1 != ngram2
+
+    ngram3 = NGram({0: [TestSchema.string], 2: [TestSchema.int]}, delta_threshold=1, timestamp_field=TestSchema.int)
+    assert ngram1 != ngram3
+    assert not ngram1 == ngram3
+
+    ngram4 = NGram({-1: [TestSchema.int], 0: [TestSchema.int]}, delta_threshold=1, timestamp_field=TestSchema.int)
+    assert ngram1 != ngram4
+    assert not ngram1 == ngram4

--- a/petastorm/tests/test_transform.py
+++ b/petastorm/tests/test_transform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import pytest
 
 from petastorm.transform import transform_schema, TransformSpec
 from petastorm.unischema import Unischema, UnischemaField
@@ -51,3 +52,10 @@ def test_change_field_transform():
                                  TransformSpec(lambda x: x,
                                                edit_fields=[UnischemaField('double', np.float16, (), None, False)]))
     assert one_added.fields['double'].numpy_dtype == np.float16
+
+
+def test_unknown_fields_in_remove_field_transform():
+    with pytest.warns(UserWarning, match='not part of the schema.*unknown_1'):
+        one_removed = transform_schema(TestSchema, TransformSpec(lambda x: x, edit_fields=None,
+                                                                 removed_fields=['int', 'unknown_1', 'unknown_2']))
+    assert set(one_removed.fields.keys()) == {'string', 'double'}

--- a/petastorm/transform.py
+++ b/petastorm/transform.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 
 from petastorm.unischema import UnischemaField, Unischema
 
@@ -49,9 +50,8 @@ def transform_schema(schema, transform_spec):
     removed_fields = set(transform_spec.removed_fields)
     unknown_field_names = removed_fields - set(schema.fields.keys())
     if unknown_field_names:
-        raise ValueError('Unexpected field names found in TransformSpec remove_fields list: "{}". '
-                         'Valid values are "{}".'
-                         .format(', '.join(removed_fields), ', '.join(schema.fields.keys())))
+        warnings.warn('remove_fields specified some field names that are not part of the schema. '
+                      'These field names will be ignored "{}". '.format(', '.join(unknown_field_names)))
 
     exclude_fields = {f[0] for f in transform_spec.edit_fields} | removed_fields
     fields = [v for k, v in schema.fields.items() if k not in exclude_fields]

--- a/petastorm/weighted_sampling_reader.py
+++ b/petastorm/weighted_sampling_reader.py
@@ -70,9 +70,10 @@ class WeightedSamplingReader(object):
                 raise ValueError('All readers passed to WeightedSamplingReader should have the same schema')
 
             # If either of ngram attribute is not None, or the ngrams are different, then we can not mix
-            if (readers[0].ngram is not None and readers[other_idx].ngram is not None) \
-                    and (readers[0].ngram.fields != readers[other_idx].ngram.fields) \
-                    or (readers[0].ngram is None != readers[other_idx].ngram is None):  # noqa
+            both_have_ngram = (readers[0].ngram is not None) and (readers[other_idx].ngram is not None)
+            ngram_differ = both_have_ngram and readers[0].ngram != readers[other_idx].ngram
+            only_one_have_ngram = (readers[0].ngram is None) != (readers[other_idx].ngram is None)
+            if only_one_have_ngram or ngram_differ:
                 raise ValueError('All readers passed to WeightedSamplingReader should have the same ngram spec')
 
         self.batched_output = readers[0].batched_output


### PR DESCRIPTION
- Don't fail transform if unknown fields are encountered. Warn instead.
- Fixing ngram equivalence check in weighted_sampling_reader.
- Adding ngram eq operator implementation
