### PR TITLE
Do not use zero-memory-copy feature of zmq to prevent large memory footprint swings.

### DIFF
--- a/petastorm/workers_pool/tests/test_workers_pool.py
+++ b/petastorm/workers_pool/tests/test_workers_pool.py
@@ -46,7 +46,8 @@ class TestWorkersPool(unittest.TestCase):
         pool.join()
 
     def test_passing_args_processes(self):
-        self._passing_args_impl(lambda: ProcessPool(10))
+        for zmq_copy_buffers in [False, True]:
+            self._passing_args_impl(lambda do_copy=zmq_copy_buffers: ProcessPool(10, zmq_copy_buffers=do_copy))
 
     def test_passing_args_threads(self):
         self._passing_args_impl(lambda: ThreadPool(10))


### PR DESCRIPTION
Added `zmq_copy_buffers` argument to the `ProcessPool` constructor. It controls whether we will use copy=True/False argument of recv_multipart.
Unfortunately, copy=False does not play nice with Python GC (at least with its default values of thresholds) and will result in wild memory footprint swings when working with large buffers (such as images).
Copying memory appears to be a safer option for common user scenario. Control over this setting is currently not exposed to users of `make_reader` or `make_batch_reader` interfaces, but may be added in the future.
In advanced scenarios, users may construct `Reader` object manually and configure it with a custom configured `ProcessPool` object.