### PR TITLE
Fix failure due to partition fields values returned by pyarrow read.

### DIFF
--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -86,3 +86,15 @@ def test_string_partition(reader_factory, tmpdir, partition_by):
         row_ids_batched = [row.id for row in reader]
     actual_row_ids = list(itertools.chain(*row_ids_batched))
     assert len(data) == len(actual_row_ids)
+
+
+@pytest.mark.parametrize('reader_factory', _D)
+def test_partitioned_field_is_not_queried(reader_factory, tmpdir):
+    """Try datasets partitioned by a string, integer and string+integer fields"""
+    url = 'file://' + tmpdir.strpath
+
+    data = create_test_scalar_dataset(url, 10, partition_by=['id'])
+    with reader_factory(url, schema_fields=['string']) as reader:
+        all_rows = list(reader)
+    assert len(data) == len(all_rows)
+    assert all_rows[0]._fields == ('string',)


### PR DESCRIPTION
Observed the following failure with pyarrow 0.14.1 and python 2.7:
```
from petastorm.reader import Reader, make_batch_reader
path = '/tmp/train'
schema_fields = ['features']
batch_reader = make_batch_reader('file://'+path, schema_fields=schema_fields)
print(batch_reader.next())

Traceback (most recent call last):
  File "test.py", line 9, in <module>
    print(batch_reader.next())
  File "/home/.../lib/python3.7/site-packages/petastorm/reader.py", line 616, in next
    return self.__next__()
  File "/home/.../lib/python3.7/site-packages/petastorm/reader.py", line 610, in __next__
    return self._results_queue_reader.read_next(self._workers_pool, self.schema, self.ngram)
  File "/home/.../lib/python3.7/site-packages/petastorm/arrow_reader_worker.py", line 79, in read_next
    return schema.make_namedtuple(**result_dict)
  File "/home/.../lib/python3.7/site-packages/petastorm/unischema.py", line 286, in make_namedtuple
    return self._get_namedtuple()(**typed_dict)
TypeError: __new__() got an unexpected keyword argument 'datestr'
```

Drop columns we did not explicitly request. This may happen when a table is partitioned. Besides columns
requested, pyarrow will also return partition values. Having these unexpected fields will break some
downstream code.