### PR TITLE
Adding image_codec accessor to CompressedImageCodec

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -62,6 +62,11 @@ class CompressedImageCodec(DataframeColumnCodec):
         self._image_codec = '.' + image_codec
         self._quality = quality
 
+    @property
+    def image_codec(self):
+        """Returns image_codec type use by the codec: png or jpeg."""
+        return self._image_codec[1:]
+
     def encode(self, unischema_field, value):
         """Encodes the image using OpenCV."""
         if unischema_field.numpy_dtype != value.dtype:

--- a/petastorm/tests/test_codec_compressed_image.py
+++ b/petastorm/tests/test_codec_compressed_image.py
@@ -41,6 +41,7 @@ def test_jpeg():
     for size in [(300, 200), (300, 200, 3)]:
         expected_image = np.random.randint(0, 255, size=size, dtype=np.uint8)
         codec = CompressedImageCodec('jpeg', quality=100)
+        assert codec.image_codec == 'jpeg'
         field = UnischemaField(name='field_image', numpy_dtype=np.uint8, shape=size, codec=codec, nullable=False)
 
         actual_image = codec.decode(field, codec.encode(field, expected_image))
@@ -77,6 +78,7 @@ def test_bad_shape():
 
 def test_bad_dtype():
     codec = CompressedImageCodec('png')
+    assert codec.image_codec == 'png'
     field = UnischemaField(name='field_image', numpy_dtype=np.uint8, shape=(10, 20), codec=codec, nullable=False)
     with pytest.raises(ValueError, match='Unexpected type'):
         codec.encode(field, np.zeros((100, 200), dtype=np.uint16))


### PR DESCRIPTION
Allows user to query the codec type: png/jpeg