### PR TITLE
Fix incorrect counting of number of row-groups per piece.

### DIFF
--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -312,6 +312,14 @@ def _split_row_groups(dataset):
     return split_pieces
 
 
+def _split_piece(piece, fs_open):
+    metadata = compat_get_metadata(piece, fs_open)
+    return [compat_make_parquet_piece(piece.path, fs_open,
+                                      row_group=row_group,
+                                      partition_keys=piece.partition_keys)
+            for row_group in range(metadata.num_row_groups)]
+
+
 def _split_row_groups_from_footers(dataset):
     """Split the row groups by reading the footers of the parquet pieces"""
 
@@ -322,14 +330,7 @@ def _split_row_groups_from_footers(dataset):
 
     thread_pool = futures.ThreadPoolExecutor()
 
-    def split_piece(piece):
-        metadata = compat_get_metadata(dataset.pieces[0], dataset.fs.open)
-        return [compat_make_parquet_piece(piece.path, dataset.fs.open,
-                                          row_group=row_group,
-                                          partition_keys=piece.partition_keys)
-                for row_group in range(metadata.num_row_groups)]
-
-    futures_list = [thread_pool.submit(split_piece, piece) for piece in dataset.pieces]
+    futures_list = [thread_pool.submit(_split_piece, piece, dataset.fs.open) for piece in dataset.pieces]
     result = [item for f in futures_list for item in f.result()]
     thread_pool.shutdown()
     return result

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -184,9 +184,12 @@ def create_test_scalar_dataset(output_url, num_rows, num_files=4, spark=None, pa
 
         spark = spark_session.getOrCreate()
         shutdown = True
+        hadoop_config = spark.sparkContext._jsc.hadoopConfiguration()
+        hadoop_config.setInt('parquet.block.size', 100)
 
     def expected_row(i):
         result = {'id': np.int32(i),
+                  'id_div_700': np.int32(i // 700),
                   'datetime': np.datetime64('2019-01-02'),
                   'timestamp': np.datetime64('2005-02-25T03:30'),
                   'string': np.unicode_('hello_{}'.format(i)),
@@ -220,6 +223,7 @@ def create_test_scalar_dataset(output_url, num_rows, num_files=4, spark=None, pa
             StructField('datetime', DateType(), False),
             StructField('float64', DoubleType(), False),
             StructField('id', IntegerType(), False),
+            StructField('id_div_700', IntegerType(), False),
         ] + maybe_int_fixed_size_list_field +
         [
             StructField('string', StringType(), False),

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -15,9 +15,11 @@ import itertools
 
 import numpy as np
 import pytest
+from pyarrow import parquet as pq
 
 from petastorm import make_batch_reader
 # pylint: disable=unnecessary-lambda
+from petastorm.compat import compat_get_metadata
 from petastorm.tests.test_common import create_test_scalar_dataset
 
 _D = [lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs)]
@@ -98,3 +100,27 @@ def test_partitioned_field_is_not_queried(reader_factory, tmpdir):
         all_rows = list(reader)
     assert len(data) == len(all_rows)
     assert all_rows[0]._fields == ('string',)
+
+
+@pytest.mark.parametrize('reader_factory', _D)
+def test_asymetric_parquet_pieces(reader_factory, tmpdir):
+    """Check that datasets with parquet files that all rows in datasets that have different number of rowgroups can
+    be fully read """
+    url = 'file://' + tmpdir.strpath
+
+    ROWS_COUNT = 1000
+    # id_div_700 forces asymetric split between partitions and hopefully get us files with different number of row
+    # groups
+    create_test_scalar_dataset(url, ROWS_COUNT, partition_by=['id_div_700'])
+
+    # We verify we have pieces with different number of row-groups
+    dataset = pq.ParquetDataset(tmpdir.strpath)
+    row_group_counts = set(compat_get_metadata(piece, dataset.fs.open).num_row_groups for piece in dataset.pieces)
+    assert len(row_group_counts) > 1
+
+    # Make sure we are not missing any rows.
+    with reader_factory(url, schema_fields=['id']) as reader:
+        row_ids_batched = [row.id for row in reader]
+        actual_row_ids = list(itertools.chain(*row_ids_batched))
+
+    assert ROWS_COUNT == len(actual_row_ids)


### PR DESCRIPTION
This bug manifests in either:
- `pyarrow.lib.ArrowIOError: The file only has <X> row groups, requested metadata for row group: <Y>` (where <X> and <Y> are integers) exception, or:
- silently - some rows in a dataset might have been silently ignored.

This issue occured when:
- using `make_batch_reader`
- number of row-groups in different parquet files (pieces) is different.

The issue was in introduced in petastorm 0.7.7

Resolves #447 