### PR TITLE
Fixing MemeoryError when building docker image on docker.io

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,13 +35,13 @@ ADD petastorm /petastorm/petastorm
 RUN python3.6 -m pip install pip --upgrade
 RUN python3.6 -m pip install wheel
 RUN python3.6 -m venv /petastorm_venv3.6
-RUN /petastorm_venv3.6/bin/pip3.6 install -e /petastorm/[test,tf,torch,docs,opencv]
+RUN /petastorm_venv3.6/bin/pip3.6 install --no-cache -e /petastorm/[test,tf,torch,docs,opencv]
 RUN /petastorm_venv3.6/bin/pip3.6 uninstall -y petastorm
 
 # Set up Python2 environment
 RUN virtualenv /petastorm_venv2.7
 RUN python2.7 -m pip install pip --upgrade
-RUN /petastorm_venv2.7/bin/pip2.7 install -e /petastorm/[test,tf,torch,docs,opencv]
+RUN /petastorm_venv2.7/bin/pip2.7 install --no-cache -e /petastorm/[test,tf,torch,docs,opencv]
 RUN /petastorm_venv2.7/bin/pip2.7 uninstall -y petastorm
 
 # Clean up


### PR DESCRIPTION
Docker.io build currently fails with `MemoryError` caused by `pip3.6 install` of pytorch. Trying to apply a solution as proposed in  [here](https://discuss.pytorch.org/t/memory-error-when-installing-pytorch/8027/6)