### PR TITLE
assign transform result in _load_rows_with_predicate

### DIFF
--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -247,7 +247,7 @@ class PyDictReaderWorker(WorkerBase):
             result = filtered_decoded_predicate_rows
 
         if self._transform_spec:
-            _apply_transform_spec(result, self._transform_spec)
+            result = _apply_transform_spec(result, self._transform_spec)
 
         return result
 


### PR DESCRIPTION
I noticed that TransformSpecs were not being applied if there was also a row predicate specified, this PR updates the `_load_rows_with_predicate` function to match https://github.com/uber/petastorm/blob/master/petastorm/py_dict_reader_worker.py#L184