### PR TITLE
Allow predicates to work with more than one partition

### DIFF
--- a/petastorm/predicates.py
+++ b/petastorm/predicates.py
@@ -126,7 +126,7 @@ class in_reduce(PredicateBase):
         """
         check_list = [isinstance(p, PredicateBase) for p in predicate_list]
         if not all(check_list):
-            raise ValueError('Predicate is nor derived from PredicateBase')
+            raise ValueError('Predicate is not derived from PredicateBase')
         self._predicate_list = predicate_list
         self._reduce_func = reduce_func
 

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -406,20 +406,18 @@ def test_predicate_on_multiple_fields_batched(synthetic_dataset, reader_factory)
         assert actual.id2[0] == expected_values['id2']
 
 
+@pytest.mark.parametrize('predicate_spec', [{'invalid_field_name': 1},
+                                            dict(),
+                                            {'invalid_field_name': 1, 'id': 11},
+                                            {'invalid_field_name': 1, 'invalid_field_name_2': 11}])
 @pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES + SCALAR_ONLY_READER_FACTORIES)
-def test_predicate_with_invalid_fields(synthetic_dataset, reader_factory):
+def test_predicate_with_invalid_fields(synthetic_dataset, reader_factory, predicate_spec):
     """Try passing an invalid field name from a predicate to the reader. An error should be raised."""
-    TEST_CASES = [
-        {'invalid_field_name': 1},
-        dict(),
-        {'invalid_field_name': 1, 'id': 11},
-        {'invalid_field_name': 1, 'invalid_field_name_2': 11}]
-
-    for predicate_spec in TEST_CASES:
-        with reader_factory(synthetic_dataset.url, shuffle_row_groups=False,
-                            predicate=EqualPredicate(predicate_spec)) as reader:
-            with pytest.raises(ValueError):
-                next(reader)
+    with reader_factory(synthetic_dataset.url, shuffle_row_groups=False,
+                        predicate=EqualPredicate(predicate_spec)) as reader:
+        with pytest.raises(ValueError):
+            next(reader)
+            print("test_predicate..., next worked.")
 
 
 @pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES + SCALAR_ONLY_READER_FACTORIES)

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -417,7 +417,6 @@ def test_predicate_with_invalid_fields(synthetic_dataset, reader_factory, predic
                         predicate=EqualPredicate(predicate_spec)) as reader:
         with pytest.raises(ValueError):
             next(reader)
-            print("test_predicate..., next worked.")
 
 
 @pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES + SCALAR_ONLY_READER_FACTORIES)

--- a/petastorm/tests/test_predicates.py
+++ b/petastorm/tests/test_predicates.py
@@ -155,7 +155,6 @@ def create_single_id_dataset(tmpdir, TestSchema):
 
     def test_row_generator(x):
         """Returns a single entry in the generated dataset."""
-        print("x=", x)
         return {'id': x,
                 'test_field': x*x}
 
@@ -172,7 +171,6 @@ def create_single_id_dataset(tmpdir, TestSchema):
             .map(test_row_generator)\
             .map(lambda x: dict_to_spark_row(TestSchema, x))
 
-        print("rows_rdd=", rows_rdd)
         spark.createDataFrame(rows_rdd, TestSchema.as_spark_schema()) \
             .write \
             .partitionBy('id') \


### PR DESCRIPTION
Modified reader._apply_predicate_to_row_groups to filter row_groups when all of the predicate fields are covered by the partition fields. However, still doesn't do any filtering if one or more of the predicate fields isn't also a partition field. Added some tests to cover new functionality.
Hopefully addresses issue #487.