### PR TITLE
New PyTorch DataLoader implementation using batched operations

### DIFF
--- a/examples/timing.py
+++ b/examples/timing.py
@@ -1,0 +1,48 @@
+import time
+import numpy as np
+from petastorm.pytorch import DataLoader
+from collections import namedtuple
+import torch
+from functools import partial
+import sys
+
+
+class DummyReader(object):
+    @property
+    def is_batched_reader(self):
+        return True
+
+    def stop(self):
+        pass
+
+    def join(self):
+        pass
+
+    def __iter__(self):
+        nt = namedtuple("row", ["test"])
+        batch = nt(np.random.rand(1000, 64).astype(np.float32))
+        while True:
+            yield batch
+
+
+def main(device):
+    print("Testing DataLoader on", device)
+    reader = DummyReader()
+    for batch_size in [10, 100, 1000, 100000]:
+        iterations = 100
+        loader = DataLoader(reader, shuffling_queue_capacity=batch_size * 10, batch_size=batch_size, collate_fn=partial(torch.as_tensor, device=device))
+        it = iter(loader)
+
+        # Warmup
+        for _ in range(iterations):
+            next(it)
+        print("Done warming up")
+
+        tstart = time.time()
+        for _ in range(iterations):
+            next(it)
+        print("Samples per second for batch {}: {:.4g}".format(batch_size, (iterations * batch_size) / (time.time() - tstart)))
+
+
+if __name__ == "__main__":
+    main(sys.argv[-1] if len(sys.argv) > 1 else "cpu")

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -378,7 +378,7 @@ def get_schema_from_dataset_url(dataset_url, hdfs_driver='libhdfs3'):
     """
     resolver = FilesystemResolver(dataset_url, hdfs_driver=hdfs_driver)
     dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
-                                validate_schema=False)
+                                validate_schema=False, metadata_nthreads=10)
 
     # Get a unischema stored in the dataset metadata.
     stored_schema = get_schema(dataset)

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -165,7 +165,6 @@ class DataLoader(object):
                     row_as_dict[k] = self.collate_fn([v])
                 else:
                     row_as_dict[k] = self.collate_fn(v)
-                row_as_dict[k] = row_as_dict[k]
             self._shuffling_buffer.add_many(row_as_dict)
 
             # _yield_batches will emit as much batches as are allowed by the shuffling_buffer (RandomShufflingBuffer

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -355,7 +355,7 @@ class Reader(object):
         self.is_batched_reader = is_batched_reader
         # 1. Resolve dataset path (hdfs://, file://) and open the parquet storage (dataset)
         self.dataset = pq.ParquetDataset(dataset_path, filesystem=pyarrow_filesystem,
-                                         validate_schema=False)
+                                         validate_schema=False, metadata_nthreads=10)
 
         stored_schema = infer_or_load_unischema(self.dataset)
 

--- a/petastorm/reader_impl/shuffling_buffer.py
+++ b/petastorm/reader_impl/shuffling_buffer.py
@@ -15,8 +15,8 @@
 import abc
 from collections import deque
 
-import numpy as np
 import six
+import torch
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -83,10 +83,10 @@ class NoopShufflingBuffer(ShufflingBufferBase):
     def add_many(self, items):
         self.store.extend(items)
 
-    def retrieve(self):
+    def retrieve(self, batch_size=1):
         return self.store.popleft()
 
-    def can_retrieve(self):
+    def can_retrieve(self, batch_size=1):
         return len(self.store) > 0
 
     def can_add(self):
@@ -131,46 +131,93 @@ class RandomShufflingBuffer(ShufflingBufferBase):
         """
         self._extra_capacity = extra_capacity
         # Preallocate the shuffling buffer.
-        self._items = [None] * (shuffling_buffer_capacity + self._extra_capacity)
+        self._items = None
+        self._keys = None
         self._shuffling_queue_capacity = shuffling_buffer_capacity
         self._min_after_dequeue = min_after_retrieve
         self._size = 0
         self._done_adding = False
 
+        self._random_indices = None
+        self._sampling_size = 0
+
     def add_many(self, items):
+        if isinstance(items, dict):
+            if self._keys is None:
+                self._keys = list(items.keys())
+            items = [items[k] for k in self._keys]
+        items = [torch.as_tensor(i) for i in items]
+        if items[0].shape == ():
+            # single value buffer
+            self._keys = ""
+            items = [torch.stack(items, 0)]
+
         if self._done_adding:
             raise RuntimeError('Can not call add_many after done_adding() was called.')
 
-        if not self.can_add():
-            raise RuntimeError('Can not enqueue. Check the return value of "can_enqueue()" to check if more '
-                               'items can be added.')
-
-        # We leave self._extra_capacity slack to make sure we don't reallocate self._items array
-        expected_size = self._size + len(items)
+        expected_size = self._size + len(items[0])
         maximal_capacity = self._shuffling_queue_capacity + self._extra_capacity
         if expected_size > maximal_capacity:
             raise RuntimeError('Attempt to enqueue more elements than the capacity allows. '
                                'Current size: {}, new size {}, maximum allowed: {}'.format(self._size, expected_size,
                                                                                            maximal_capacity))
-        self._items[self._size:self._size + len(items)] = items
+
+        new_capacity = self._shuffling_queue_capacity
+        while new_capacity < expected_size:
+            # Will double capacity until it is large enough to fit new batch
+            new_capacity *= 2
+
+        if self._items is None:
+            # Create Buffer:
+            self._items = []
+            for v in items:
+                self._items.append(torch.empty((new_capacity,) + v.shape[1:], dtype=v.dtype, device=v.device))
+
+        if self._sampling_size > 0:
+            # Before we can append a new batch, we should remove used samples
+            for k, v in enumerate(self._items):
+                # We need to clone the right-side to avoid racing conditions
+                self._items[k][:self.size] = self._items[k][self._random_indices[self._sampling_size:]].clone()
+        self._random_indices = None
+        self._sampling_size = 0
+
+        if new_capacity > self._items[0].shape[0]:
+            for k, v in enumerate(self._items):
+                self._items[k] = torch.empty((new_capacity,) + v.shape[1:], dtype=v.dtype, device=v.device)
+                self._items[k][:self._size] = v[:self._size]
+
+        # Copy new items over
+        for k, v in enumerate(items):
+            self._items[k][self._size:expected_size] = v
         self._size = expected_size
 
-    def retrieve(self):
+    def retrieve(self, batch_size=1):
         if not self._done_adding and not self.can_retrieve():
             raise RuntimeError('Can not dequeue. Check the return value of "can_dequeue()" to check if any '
                                'items are available.')
-        random_index = np.random.randint(0, self._size)
-        return_value = self._items[random_index]
-        self._items[random_index] = self._items[self._size - 1]
-        self._items[self._size - 1] = None
-        self._size -= 1
-        return return_value
+        batch_size = min(batch_size, self._size)
 
-    def can_add(self):
-        return self._size < self._shuffling_queue_capacity and not self._done_adding
+        if self._random_indices is None:
+            self._sampling_size = 0
+            self._random_indices = torch.randperm(int(self._size), device=self._items[0].device)
+        idx = self._random_indices[self._sampling_size:self._sampling_size + batch_size]
+        self._sampling_size += batch_size
+        sample = []
+        for v in self._items:
+            # Clone is required because pytorch doesn't always make a copy
+            sample.append(v[idx])
+        self._size -= batch_size
+        if self._keys is not None:
+            if self._keys == "":
+                return sample[0].item()
+            return {k: v for k, v in zip(self._keys, sample)}
+        return sample
 
-    def can_retrieve(self):
-        return self._size >= self._min_after_dequeue or (self._done_adding and self._size > 0)
+    def can_add(self, batch_size=1):
+        return self._size <= self._shuffling_queue_capacity - batch_size and not self._done_adding
+
+    def can_retrieve(self, batch_size=1):
+        return self._size >= self._min_after_dequeue + batch_size - 1 or (self._done_adding and self._size > 0)
 
     @property
     def size(self):

--- a/petastorm/tests/test_shuffling_buffer.py
+++ b/petastorm/tests/test_shuffling_buffer.py
@@ -82,8 +82,6 @@ def test_random_shuffling_buffer_can_add_retrieve_flags():
     # shuffling_buffer_capacity
     q.add_many([6, 7, 8, 9])
     assert not q.can_add()
-    with pytest.raises(RuntimeError):
-        q.add_many([1])
     assert q.can_retrieve()
     assert q.size == 8
 


### PR DESCRIPTION
The current DataLoader implementation relies on python iteration over individual rows of a parquet dataset. This is reasonable for small datasets but runs into throughput limitations:

Previous timing:
```
Samples per second for batch 10: 7.556e+04
Samples per second for batch 100: 1.001e+05
Samples per second for batch 1000: 1.083e+05
Samples per second for batch 100000: 4.364e+04
```

The new approach converts data into torch format BEFORE appending to the shuffling buffer and then relies on batched operations to perform all data appending/sampling.

New timing:
```
Samples per second for batch 10: 4.363e+05
Samples per second for batch 100: 1.468e+06
Samples per second for batch 1000: 1.607e+06
Samples per second for batch 100000: 1.141e+06
```
New timing with GPU-buffering:
```
Samples per second for batch 10: 3.87e+05
Samples per second for batch 100: 1.95e+06
Samples per second for batch 1000: 2.307e+06
Samples per second for batch 100000: 5.053e+06
```

In the best-case scenario, the samples/s increases 2 orders of magnitude. Although image-based problems would likely not achieve this throughput, these numbers are more representative of the throughput on tabular-data problems.

The proposed changes can be used out-of-the-box in most scenarios.

There are still many improvements that can be made to the ShufflingBuffer logic, but this implementation provides an initial step in that direction.