### PR TITLE
Fix spurious legacy-regex rule warning

### DIFF
--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -293,8 +293,8 @@ def test_match_unischema_fields():
 
     assert match_unischema_fields(TestSchema, ['.*nt.*6']) == [TestSchema.uint16]
     assert match_unischema_fields(TestSchema, ['nomatch']) == []
-    assert match_unischema_fields(TestSchema, ['.*']) == list(TestSchema.fields.values())
-    assert match_unischema_fields(TestSchema, ['int32', 'uint8']) == [TestSchema.int32, TestSchema.uint8]
+    assert set(match_unischema_fields(TestSchema, ['.*'])) == set(TestSchema.fields.values())
+    assert set(match_unischema_fields(TestSchema, ['int32', 'uint8'])) == {TestSchema.int32, TestSchema.uint8}
 
 
 def test_match_unischema_fields_legacy_warning():
@@ -312,6 +312,11 @@ def test_match_unischema_fields_legacy_warning():
     # uint8 and uint16 would have been matched using the old method, but not the new one
     with pytest.warns(UserWarning, match=r'schema_fields behavior has changed.*uint16, uint8'):
         assert match_unischema_fields(TestSchema, ['uint']) == []
+
+    # Now, all fields will be matched, but in different order (legacy vs current). Make sure we don't issue a warning.
+    with pytest.warns(None) as unexpected_warnings:
+        match_unischema_fields(TestSchema, ['int', 'uint8', 'uint16', 'int32'])
+    assert not unexpected_warnings
 
 
 def test_arrow_schema_convertion():

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -421,13 +421,13 @@ def match_unischema_fields(schema, field_regex):
       expression patterns given by ``field_regex``.
     """
     if field_regex:
-        unischema_fields = []
-        legacy_unischema_fields = []
+        unischema_fields = set()
+        legacy_unischema_fields = set()
         for pattern in field_regex:
-            unischema_fields.extend(
-                [field for field_name, field in schema.fields.items() if _fullmatch(pattern, field_name)])
-            legacy_unischema_fields.extend([field for field_name, field in schema.fields.items()
-                                            if re.match(pattern, field_name)])
+            unischema_fields |= {field for field_name, field in schema.fields.items() if
+                                 _fullmatch(pattern, field_name)}
+            legacy_unischema_fields |= {field for field_name, field in schema.fields.items()
+                                        if re.match(pattern, field_name)}
         if unischema_fields != legacy_unischema_fields:
             field_names = {f.name for f in unischema_fields}
             legacy_field_names = {f.name for f in legacy_unischema_fields}
@@ -436,9 +436,9 @@ def match_unischema_fields(schema, field_regex):
             warnings.warn('schema_fields behavior has changed. Now, regular expression pattern must match'
                           ' the entire field name. The change in the behavior affects '
                           'the following fields: {}'.format(', '.join(diff_names)))
+        return list(unischema_fields)
     else:
-        unischema_fields = field_regex
-    return unischema_fields
+        return []
 
 
 def _numpy_and_codec_from_arrow_type(field_type):


### PR DESCRIPTION
The warning was occuring when both legacy and the new rule produced the
same overall set of fields, but maybe in different order. Although, both
rules would behave the same from the user perspective, they would see a
warning. The warning would be bogus because it wouldn't contain any
field names.