### PR TITLE
Verify that scalars and not arrays are passed to a ScalarCodec instance

### DIFF
--- a/petastorm/codecs.py
+++ b/petastorm/codecs.py
@@ -201,6 +201,13 @@ class ScalarCodec(DataframeColumnCodec):
         # (currently works only with make_batch_reader). We should move all pyspark related code into a separate module
         import pyspark.sql.types as sql_types
 
+        # We treat ndarrays with shape=() as scalars
+        unsized_numpy_array = isinstance(value, np.ndarray) and value.shape == ()
+        # Validate the input to be a scalar (or an unsized numpy array)
+        if not unsized_numpy_array and hasattr(value, '__len__') and (not isinstance(value, str)):
+            raise TypeError('Expected a scalar as a value for field \'{}\'. '
+                            'Got a non-numpy type\'{}\''.format(unischema_field.name, type(value)))
+
         if unischema_field.shape:
             raise ValueError('The shape field of unischema_field \'%s\' must be an empty tuple (i.e. \'()\' '
                              'to indicate a scalar. However, the actual shape is %s',

--- a/petastorm/tests/test_codec_scalar.py
+++ b/petastorm/tests/test_codec_scalar.py
@@ -115,3 +115,11 @@ def test_encode_scalar_string():
     encoded = codec.encode(field, expected)
     assert isinstance(encoded, str)
     assert expected == encoded
+
+
+@pytest.mark.parametrize("non_scalar_value", [[1.2], np.asarray([3.4]), [5, 6]])
+def test_encode_non_scalar_type_is_passed(non_scalar_value):
+    codec = ScalarCodec(FloatType())
+    field = UnischemaField(name='field_float', numpy_dtype=np.float32, shape=(), codec=codec, nullable=False)
+    with pytest.raises(TypeError, match='Expected a scalar'):
+        codec.encode(field, non_scalar_value)

--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -120,7 +120,7 @@ def test_dict_to_spark_row_field_validation_scalar_types():
         isinstance(dict_to_spark_row(TestSchema, {'string_field': None}), Row)
 
     # Wrong field type
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         isinstance(dict_to_spark_row(TestSchema, {'string_field': []}), Row)
 
 


### PR DESCRIPTION
Validating types earlier in the code execution paths with a clear
message is better than vague errors from downstream code.