### PR TITLE
Make `make_batch_reader` TransformSpec support output multi-dimensional array type.

### DIFF
--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -184,7 +184,7 @@ class ArrowReaderWorker(WorkerBase):
             transformed_schema_column_set = set([f.name for f in self._transformed_schema.fields.values()])
 
             if transformed_result_column_set != transformed_schema_column_set:
-                raise ValueError('Transformed result columns ({rs}) do not match required schema columns({sc})'
+                raise ValueError('Transformed result columns ({rc}) do not match required schema columns({sc})'
                                  .format(rc=','.join(transformed_result_column_set),
                                          sc=','.join(transformed_schema_column_set)))
 
@@ -201,7 +201,7 @@ class ArrowReaderWorker(WorkerBase):
             for field in self._transformed_schema.fields.values():
                 if len(field.shape) > 1:
                     transformed_result[field.name] = transformed_result[field.name] \
-                        .map(lambda x: check_shape_and_ravel(x, field))
+                        .map(lambda x: check_shape_and_ravel(x, field))  # pylint: disable=cell-var-from-loop
 
             result = pa.Table.from_pandas(transformed_result, preserve_index=False)
 

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -67,7 +67,12 @@ class ArrowReaderWorkerResultsQueueReader(object):
                     # Assuming all lists are of the same length, hence we can collate them into a matrix
                     list_of_lists = column_as_numpy
                     try:
-                        result_dict[column_name] = np.vstack(list_of_lists.tolist())
+                        col_data = np.vstack(list_of_lists.tolist())
+                        shape = schema.fields[column_name].shape
+                        if len(shape) > 1:
+                            col_data = col_data.reshape((len(list_of_lists),) + shape)
+                        result_dict[column_name] = col_data
+
                     except ValueError:
                         raise RuntimeError('Length of all values in column \'{}\' are expected to be the same length. '
                                            'Got the following set of lengths: \'{}\''
@@ -93,6 +98,7 @@ class ArrowReaderWorker(WorkerBase):
         self._split_pieces = args[4]
         self._local_cache = args[5]
         self._transform_spec = args[6]
+        self._transformed_schema = args[7]
 
         if self._ngram:
             raise NotImplementedError('ngrams are not supported by ArrowReaderWorker')
@@ -173,6 +179,20 @@ class ArrowReaderWorker(WorkerBase):
             # TransformSpec(removed_fields=['some field'])
             for field_to_remove in set(transformed_result.columns) & set(self._transform_spec.removed_fields):
                 del transformed_result[field_to_remove]
+
+            for field in self._transformed_schema.fields.values():
+                if len(field.shape) > 1:
+                    def check_and_ravel(x):
+                        if not isinstance(x, np.ndarray):
+                            raise ValueError('field {name} must be numpy array type.'.format(name=field.name))
+                        if x.shape != field.shape:
+                            raise ValueError('field {name} must be the shape {shape}'
+                                             .format(name=field.name, shape=field.shape))
+                        if not x.flags.c_contiguous:
+                            raise ValueError('Only support row major multi-dimensional array.')
+                        return x.ravel()
+
+                    transformed_result[field.name] = transformed_result[field.name].map(check_and_ravel)
 
             result = pa.Table.from_pandas(transformed_result, preserve_index=False)
 

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -406,7 +406,7 @@ class Reader(object):
 
         # 5. Start workers pool
         self._workers_pool.start(worker_class, (pyarrow_filesystem, dataset_path, storage_schema, self.ngram,
-                                                row_groups, cache, transform_spec),
+                                                row_groups, cache, transform_spec, self.schema),
                                  ventilator=self.ventilator)
         logger.debug('Workers pool started')
 

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -193,5 +193,5 @@ def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
         removed_fields=list(scalar_dataset.data[0].keys())
     )
 
-    with pytest.raises(ValueError, match='field tensor_col_1 must be the shape (2, 3)'):
+    with pytest.raises(Exception):
         reader_factory(scalar_dataset.url, transform_spec=spec2)

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -19,10 +19,12 @@ import pytest
 from pyarrow import parquet as pq
 
 from petastorm import make_batch_reader
+from petastorm.arrow_reader_worker import ArrowReaderWorker
 # pylint: disable=unnecessary-lambda
 from petastorm.compat import compat_get_metadata
 from petastorm.tests.test_common import create_test_scalar_dataset
 from petastorm.transform import TransformSpec
+from petastorm.unischema import UnischemaField
 
 _D = [lambda url, **kwargs: make_batch_reader(url, reader_pool_type='dummy', **kwargs)]
 
@@ -169,17 +171,39 @@ def test_invalid_and_valid_column_names(scalar_dataset, reader_factory):
 
 @pytest.mark.parametrize('reader_factory', _D)
 def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
+
+    field1 = UnischemaField(name='abc', shape=(2, 3), numpy_dtype=np.float32)
+
+    with pytest.raises(ValueError, match='field abc must be numpy array type'):
+        ArrowReaderWorker._check_shape_and_ravel('xyz', field1)
+
+    with pytest.raises(ValueError, match='field abc must be the shape (2, 3)'):
+        ArrowReaderWorker._check_shape_and_ravel(np.zeros((2, 5)), field1)
+
+    with pytest.raises(ValueError, match='field abc error: only support row major multi-dimensional array'):
+        ArrowReaderWorker._check_shape_and_ravel(np.zeros((2, 3), order='F'), field1)
+
+    assert (6,) == ArrowReaderWorker._check_shape_and_ravel(np.zeros((2, 3)), field1).shape
+
     def preproc_fn1(x):
-        return pd.DataFrame({'tensor_col_1': x['id'].map(lambda _: np.random.rand(2, 3))})
+        return pd.DataFrame({
+            'tensor_col_1': x['id'].map(lambda _: np.random.rand(2, 3)),
+            'tensor_col_2': x['id'].map(lambda _: np.random.rand(3, 4, 5)),
+        })
+    edit_fields = [
+        ('tensor_col_1', np.float32, (2, 3), False),
+        ('tensor_col_2', np.float32, (3, 4, 5), False),
+    ]
 
     # This spec will remove all input columns and return one new column 'tensor_col_1' with shape (2, 3)
     spec1 = TransformSpec(
         preproc_fn1,
-        edit_fields=[('tensor_col_1', np.float32, (2, 3), False)],
+        edit_fields=edit_fields,
         removed_fields=list(scalar_dataset.data[0].keys())
     )
 
     with reader_factory(scalar_dataset.url, transform_spec=spec1) as reader:
         sample = next(reader)._asdict()
-        assert len(sample) == 1
-        assert (2, 3) == sample['tensor_col_1'].shape[1:]
+        assert len(sample) == 2
+        assert (2, 3) == sample['tensor_col_1'].shape[1:] and \
+            (3, 4, 5) == sample['tensor_col_2'].shape[1:]

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -183,3 +183,15 @@ def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
         sample = next(reader)._asdict()
         assert len(sample) == 1
         assert (2, 3) == sample['tensor_col_1'].shape
+
+    def preproc_fn2(x):
+        return pd.DataFrame({'tensor_col_1': x['id'].map(lambda _: np.random.rand(2, 5))})
+
+    spec2 = TransformSpec(
+        preproc_fn2,
+        edit_fields=[('tensor_col_1', np.float32, (2, 3), False)],
+        removed_fields=list(scalar_dataset.data[0].keys())
+    )
+
+    with pytest.raises(ValueError, match='field tensor_col_1 must be the shape (2, 3)'):
+        reader_factory(scalar_dataset.url, transform_spec=spec2)

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -182,7 +182,7 @@ def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
     with reader_factory(scalar_dataset.url, transform_spec=spec1) as reader:
         sample = next(reader)._asdict()
         assert len(sample) == 1
-        assert (2, 3) == sample['tensor_col_1'].shape
+        assert (2, 3) == sample['tensor_col_1'].shape[1:]
 
     def preproc_fn2(x):
         return pd.DataFrame({'tensor_col_1': x['id'].map(lambda _: np.random.rand(2, 5))})

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -177,7 +177,7 @@ def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
     with pytest.raises(ValueError, match='field abc must be numpy array type'):
         ArrowReaderWorker._check_shape_and_ravel('xyz', field1)
 
-    with pytest.raises(ValueError, match='field abc must be the shape (2, 3)'):
+    with pytest.raises(ValueError, match='field abc must be the shape'):
         ArrowReaderWorker._check_shape_and_ravel(np.zeros((2, 5)), field1)
 
     with pytest.raises(ValueError, match='field abc error: only support row major multi-dimensional array'):

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -183,15 +183,3 @@ def test_transform_spec_support_return_tensor(scalar_dataset, reader_factory):
         sample = next(reader)._asdict()
         assert len(sample) == 1
         assert (2, 3) == sample['tensor_col_1'].shape[1:]
-
-    def preproc_fn2(x):
-        return pd.DataFrame({'tensor_col_1': x['id'].map(lambda _: np.random.rand(2, 5))})
-
-    spec2 = TransformSpec(
-        preproc_fn2,
-        edit_fields=[('tensor_col_1', np.float32, (2, 3), False)],
-        removed_fields=list(scalar_dataset.data[0].keys())
-    )
-
-    with pytest.raises(Exception):
-        reader_factory(scalar_dataset.url, transform_spec=spec2)


### PR DESCRIPTION
Make `make_batch_reader` TransformSpec support output multi-dimensional array type.


## Why we need this feature ?
The project: Simplify data conversion from Spark to TensorFlow: Spark converter basic implementation is implemented via `make_batch_reader` API. And user may want to do some preprocessing and return some tensor (multi-dimensional array) in the preprocess function.

Currently, `make_batch_reader` TransformSpec func only allow return one-dimensional array because of pyarrow format limitation.

## How does the PR address it ?
This PR address this issue. The approach is:

Flatten the multi-dimensional array returned by TransformSpec func, and in `ArrowReaderWorkerResultsQueueReader` loading data code, reshape back to the specified shape.
Note reshape is a in-place operation so it won't affect performance.

## Manual test code

~~~python
from petastorm import make_batch_reader
from petastorm.transform import TransformSpec

import os
import pandas as pd
import sys
import numpy as np
from pyspark.sql.functions import pandas_udf

@pandas_udf('array<float>')
def gen_array(v):
  return v.map(lambda x: np.random.rand(10))

df1 = spark.range(6).withColumn('v', gen_array('id'))

data_url = 'file:///tmp/t0001'
data_path = '/tmp/t0001'
df1.repartition(2).write.mode('overwrite').option("compression", "uncompressed").option("parquet.block.size", 1024 * 1024).parquet(data_url)

def preproc_fn(x):
  # reshape column 'v' to (2, 5) shape.
  x2 = pd.DataFrame({'v': x['v'].map(lambda x: x.reshape((2, 5))), 'id': x['id'] + 10000})
  return x2

spec = TransformSpec(
  preproc_fn,
  [('v', np.float32, (2, 5), False), ('id', np.int64, (), False)]
)

reader = make_batch_reader(data_url, num_epochs=1, transform_spec=spec)
for i in reader:
    print(i)
~~~
