### PR TITLE
Simplify data conversion from Spark to TensorFlow: support tensorflow dataset advance arguments

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -26,12 +26,13 @@ from pyarrow import LocalFileSystem
 from pyspark.sql.session import SparkSession
 from six.moves.urllib.parse import urlparse
 
-import petastorm
+from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
+
 
 def _get_spark_session():
     return SparkSession.builder.getOrCreate()
@@ -243,7 +244,7 @@ class TFDatasetContextManager(object):
         from petastorm.tf_utils import make_petastorm_dataset
         import tensorflow as tf
 
-        self.reader = petastorm.make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
+        self.reader = make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
 
         dataset = make_petastorm_dataset(self.reader) \
             .flat_map(tf.data.Dataset.from_tensor_slices)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -136,8 +136,9 @@ def get_env_rank_and_size():
 
 def check_rank_and_size(petastorm_reader_kwargs):
     """
-    :param check whether the cur_shard and shard_count args are set correctly.
-    :return If return False, denotes user may set cur_shard and shard_count wrong.
+    Check whether the cur_shard and shard_count args are consistent with environment variables.
+    If not consistent with environment variables, return False.
+    If there're no related environment variable set, return True.
     """
     env_rank, env_size = get_env_rank_and_size()
     if env_rank is not None and env_size is not None:
@@ -213,7 +214,6 @@ class SparkDatasetConverter(object):
         petastorm_reader_kwargs['num_epochs'] = num_epochs
         petastorm_reader_kwargs['workers_count'] = workers_count
 
-        env_rank, env_size = get_env_rank_and_size()
         if check_rank_and_size(petastorm_reader_kwargs):
             logger.warning('The petastorm arguments cur_shard and shard_count is not '
                            'consistent with detected MPI/horovod environments, does '

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -134,7 +134,7 @@ def get_env_rank_and_size():
     return None, None
 
 
-def check_rank_and_size(petastorm_reader_kwargs):
+def is_rank_and_size_consistent_with_env(petastorm_reader_kwargs):
     """
     Check whether the cur_shard and shard_count args are consistent with environment variables.
     If not consistent with environment variables, return False.
@@ -212,9 +212,12 @@ class SparkDatasetConverter(object):
 
         # override some arguments default values of petastorm reader
         petastorm_reader_kwargs['num_epochs'] = num_epochs
+        if workers_count is None:
+            # TODO: generate a best tuned value for default worker count value
+            workers_count = 4
         petastorm_reader_kwargs['workers_count'] = workers_count
 
-        if check_rank_and_size(petastorm_reader_kwargs):
+        if not is_rank_and_size_consistent_with_env(petastorm_reader_kwargs):
             logger.warning('The petastorm arguments cur_shard and shard_count is not '
                            'consistent with detected MPI/horovod environments, does '
                            'each work sample the whole dataset?')

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -26,7 +26,7 @@ from pyarrow import LocalFileSystem
 from pyspark.sql.session import SparkSession
 from six.moves.urllib.parse import urlparse
 
-import petastorm
+from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
@@ -244,7 +244,7 @@ class TFDatasetContextManager(object):
         from petastorm.tf_utils import make_petastorm_dataset
         import tensorflow as tf
 
-        self.reader = petastorm.make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
+        self.reader = make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
 
         dataset = make_petastorm_dataset(self.reader) \
             .flat_map(tf.data.Dataset.from_tensor_slices)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -26,7 +26,7 @@ from pyarrow import LocalFileSystem
 from pyspark.sql.session import SparkSession
 from six.moves.urllib.parse import urlparse
 
-from petastorm import make_batch_reader
+import petastorm
 from petastorm.fs_utils import FilesystemResolver
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
@@ -244,7 +244,7 @@ class TFDatasetContextManager(object):
         from petastorm.tf_utils import make_petastorm_dataset
         import tensorflow as tf
 
-        self.reader = make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
+        self.reader = petastorm.make_batch_reader(self.data_url, **self.petastorm_reader_kwargs)
 
         dataset = make_petastorm_dataset(self.reader) \
             .flat_map(tf.data.Dataset.from_tensor_slices)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -27,7 +27,7 @@ from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
                                StringType, StructField, StructType)
 from six.moves.urllib.parse import urlparse
 
-import petastorm
+from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
 from petastorm.spark import make_spark_converter
 from petastorm.spark import spark_dataset_converter
@@ -258,19 +258,19 @@ def test_tf_dataset_batch_size(test_ctx):
 @contextmanager
 def mock_make_batch_reader():
     captured_args = []
-    original_make_batch_reader = petastorm.make_batch_reader
+    import petastorm.spark
 
     def mock_fn(dataset_url, **kwargs):
         reader_args = {'dataset_url': dataset_url}
         reader_args.update(kwargs)
         captured_args.append(reader_args)
-        return original_make_batch_reader(dataset_url, **kwargs)
+        return make_batch_reader(dataset_url, **kwargs)
 
-    petastorm.make_batch_reader = mock_fn
+    petastorm.spark.spark_dataset_converter.make_batch_reader = mock_fn
     try:
         yield captured_args
     finally:
-        petastorm.make_batch_reader = original_make_batch_reader
+        petastorm.spark.spark_dataset_converter.make_batch_reader = make_batch_reader
 
 
 def test_tf_dataset_petastorm_args(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -274,16 +274,16 @@ def mock_make_batch_reader():
 
 
 def test_tf_dataset_petastorm_args(test_ctx):
-    df1 = test_ctx.spark.range(100, 101)
+    df1 = test_ctx.spark.range(100).repartition(4)
     conv1 = make_spark_converter(df1)
 
     with mock_make_batch_reader() as captured_args:
-        with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=3):
+        with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=4):
             pass
         peta_args = captured_args[0]
         assert peta_args['reader_pool_type'] == 'dummy' and \
             peta_args['cur_shard'] == 1 and \
-            peta_args['shard_count'] == 3 and \
+            peta_args['shard_count'] == 4 and \
             peta_args['num_epochs'] is None and \
             peta_args['workers_count'] == 4
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -246,7 +246,7 @@ def test_tf_dataset_batch_size(test_ctx):
     batch_size = 30
     converter1 = make_spark_converter(df1)
 
-    with converter1.make_tf_dataset(batch_size) as dataset:
+    with converter1.make_tf_dataset(batch_size=batch_size) as dataset:
         iterator = dataset.make_one_shot_iterator()
         tensor = iterator.get_next()
         with tf.Session() as sess:
@@ -261,7 +261,9 @@ def mock_make_batch_reader():
     original_make_batch_reader = petastorm.make_batch_reader
 
     def mock_fn(dataset_url, **kwargs):
-        captured_args.append({'dataset_url': dataset_url, **kwargs})
+        reader_args = {'dataset_url': dataset_url}
+        reader_args.update(kwargs)
+        captured_args.append(reader_args)
         return original_make_batch_reader(dataset_url, **kwargs)
 
     petastorm.make_batch_reader = mock_fn

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -27,7 +27,7 @@ from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
                                StringType, StructField, StructType)
 from six.moves.urllib.parse import urlparse
 
-from petastorm import make_batch_reader
+import petastorm
 from petastorm.fs_utils import FilesystemResolver
 from petastorm.spark import make_spark_converter
 from petastorm.spark import spark_dataset_converter
@@ -258,19 +258,19 @@ def test_tf_dataset_batch_size(test_ctx):
 @contextmanager
 def mock_make_batch_reader():
     captured_args = []
-    import petastorm.spark
+    original_make_batch_reader = petastorm.make_batch_reader
 
     def mock_fn(dataset_url, **kwargs):
         reader_args = {'dataset_url': dataset_url}
         reader_args.update(kwargs)
         captured_args.append(reader_args)
-        return make_batch_reader(dataset_url, **kwargs)
+        return original_make_batch_reader(dataset_url, **kwargs)
 
-    petastorm.spark.spark_dataset_converter.make_batch_reader = mock_fn
+    petastorm.make_batch_reader = mock_fn
     try:
         yield captured_args
     finally:
-        petastorm.spark.spark_dataset_converter.make_batch_reader = make_batch_reader
+        petastorm.make_batch_reader = original_make_batch_reader
 
 
 def test_tf_dataset_petastorm_args(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -260,28 +260,27 @@ def test_tf_dataset_batch_size(test_ctx):
     assert len(ts.id) == batch_size
 
 
-@mock.patch('petastorm.spark.spark_dataset_converter.make_batch_reader')
-def test_tf_dataset_petastorm_args(test_ctx, mock_make_batch_reader):
+def test_tf_dataset_petastorm_args(test_ctx):
     df1 = test_ctx.spark.range(100).repartition(4)
     conv1 = make_spark_converter(df1)
 
-    mock_make_batch_reader.return_value = make_batch_reader(conv1.cache_dir_url)
+    with mock.patch('petastorm.spark.spark_dataset_converter.make_batch_reader') as mock_make_batch_reader:
+        mock_make_batch_reader.return_value = make_batch_reader(conv1.cache_dir_url)
+        with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=4):
+            pass
+        peta_args = mock_make_batch_reader.call_args.kwargs
+        assert peta_args['reader_pool_type'] == 'dummy' and \
+            peta_args['cur_shard'] == 1 and \
+            peta_args['shard_count'] == 4 and \
+            peta_args['num_epochs'] is None and \
+            peta_args['workers_count'] == 4
 
-    with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=4):
-        pass
-
-    peta_args = mock_make_batch_reader.call_args.kwargs
-    assert peta_args['reader_pool_type'] == 'dummy' and \
-        peta_args['cur_shard'] == 1 and \
-        peta_args['shard_count'] == 4 and \
-        peta_args['num_epochs'] is None and \
-        peta_args['workers_count'] == 4
-
-    with conv1.make_tf_dataset(num_epochs=1, workers_count=2):
-        pass
-
-    peta_args = mock_make_batch_reader.call_args.kwargs
-    assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
+    with mock.patch('petastorm.spark.spark_dataset_converter.make_batch_reader') as mock_make_batch_reader:
+        mock_make_batch_reader.return_value = make_batch_reader(conv1.cache_dir_url)
+        with conv1.make_tf_dataset(num_epochs=1, workers_count=2):
+            pass
+        peta_args = mock_make_batch_reader.call_args.kwargs
+        assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
 
 
 def test_horovod_rank_compatibility(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -21,9 +21,9 @@ import numpy as np
 import tensorflow as tf
 
 try:
-    from unittest import mock
-except ImportError:
     from mock import mock
+except ImportError:
+    from unittest import mock
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -27,6 +27,7 @@ from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
                                StringType, StructField, StructType)
 from six.moves.urllib.parse import urlparse
 
+from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
 from petastorm.spark import make_spark_converter
 from petastorm.spark import spark_dataset_converter
@@ -257,20 +258,19 @@ def test_tf_dataset_batch_size(test_ctx):
 @contextmanager
 def mock_make_batch_reader():
     captured_args = []
-    import petastorm
-    original_make_batch_reader = petastorm.make_batch_reader
+    import petastorm.spark
 
     def mock_fn(dataset_url, **kwargs):
         reader_args = {'dataset_url': dataset_url}
         reader_args.update(kwargs)
         captured_args.append(reader_args)
-        return original_make_batch_reader(dataset_url, **kwargs)
+        return make_batch_reader(dataset_url, **kwargs)
 
-    petastorm.make_batch_reader = mock_fn
+    petastorm.spark.spark_dataset_converter.make_batch_reader = mock_fn
     try:
         yield captured_args
     finally:
-        petastorm.make_batch_reader = original_make_batch_reader
+        petastorm.spark.spark_dataset_converter.make_batch_reader = make_batch_reader
 
 
 def test_tf_dataset_petastorm_args(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -278,7 +278,8 @@ def test_tf_dataset_petastorm_args(test_ctx):
     conv1 = make_spark_converter(df1)
 
     with mock_make_batch_reader() as captured_args:
-        conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=3)
+        with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=3):
+            pass
         peta_args = captured_args[0]
         assert peta_args['reader_pool_type'] == 'dummy' and \
             peta_args['cur_shard'] == 1 and \
@@ -288,6 +289,7 @@ def test_tf_dataset_petastorm_args(test_ctx):
 
     # Test default value overridden arguments.
     with mock_make_batch_reader() as captured_args:
-        conv1.make_tf_dataset(num_epochs=1, workers_count=2)
+        with conv1.make_tf_dataset(num_epochs=1, workers_count=2):
+            pass
         peta_args = captured_args[0]
         assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -36,7 +36,8 @@ from petastorm.fs_utils import FilesystemResolver
 from petastorm.spark import make_spark_converter
 from petastorm.spark import spark_dataset_converter
 from petastorm.spark.spark_dataset_converter import register_delete_dir_handler, \
-    _check_url, _get_parent_cache_dir_url, _make_sub_dir_url
+    _check_url, _get_parent_cache_dir_url, _make_sub_dir_url, \
+    _get_horovod_rank_and_size, _is_rank_and_size_consistent_with_horovod
 
 
 class TestContext(object):
@@ -281,3 +282,10 @@ def test_tf_dataset_petastorm_args(test_ctx, mock_make_batch_reader):
 
     peta_args = mock_make_batch_reader.call_args.kwargs
     assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
+
+
+def test_horovod_rank_compatibility(test_ctx):
+    assert _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=3, hvd_rank=1, hvd_size=3)
+    assert _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=3, hvd_rank=None, hvd_size=None)
+    assert not _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=2, hvd_rank=1, hvd_size=3)
+    assert not _is_rank_and_size_consistent_with_horovod(cur_shard=0, shard_count=3, hvd_rank=1, hvd_size=3)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -285,6 +285,15 @@ def test_tf_dataset_petastorm_args(test_ctx, mock_make_batch_reader):
 
 
 def test_horovod_rank_compatibility(test_ctx):
+    with mock.patch.dict(os.environ, {'HOROVOD_RANK': '1', 'HOROVOD_SIZE': '3'}, clear=True):
+        assert (1, 3) == _get_horovod_rank_and_size()
+    with mock.patch.dict(os.environ, {'OMPI_COMM_WORLD_RANK': '1', 'OMPI_COMM_WORLD_SIZE': '3'}, clear=True):
+        assert (1, 3) == _get_horovod_rank_and_size()
+    with mock.patch.dict(os.environ, {'PMI_RANK': '1', 'PMI_SIZE': '3'}, clear=True):
+        assert (1, 3) == _get_horovod_rank_and_size()
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert (None, None) == _get_horovod_rank_and_size()
+
     assert _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=3, hvd_rank=1, hvd_size=3)
     assert _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=3, hvd_rank=None, hvd_size=None)
     assert not _is_rank_and_size_consistent_with_horovod(cur_shard=1, shard_count=2, hvd_rank=1, hvd_size=3)


### PR DESCRIPTION
## What changes are proposed in this PR?
Add `converter.make_tf_dataset()` with advanced params.

## API
~~~python
class SparkDatasetConverter(object):
    """
    A `SparkDatasetConverter` object holds one materialized spark dataframe and
    can be used to make one or more tensorflow datasets or torch dataloaders.
    The `SparkDatasetConverter` object is picklable and can be used in remote
    processes.
    See `make_spark_converter`
    """
    
    def make_tf_dataset(
            self,
            batch_size=32,
            prefetch=None,
            num_epochs=None,
            workers_count=4,
            **petastorm_reader_kwargs
    ):
        """
        Make a tensorflow dataset.

        This method will do the following two steps:
          1) Open a petastorm reader on the materialized dataset dir.
          2) Create a tensorflow dataset based on the reader created in (1)

        :param batch_size: The number of items to return per batch
        :param prefetch: Prefetch size for tensorflow dataset. If None will use
            tensorflow autotune size. Note only available on tensorflow>=1.14
        :param num_epochs: An epoch is a single pass over all rows in the dataset.
            Setting ``num_epochs`` to ``None`` will result in an infinite number
            of epochs.
        :param workers_count: An int for the number of workers to use in the
            reader pool. This only is used for the thread or process pool. Default value 4.
        :param petastorm_reader_kwargs: arguments for `petastorm.make_batch_reader()`,
            exclude these arguments: "dataset_url", "num_epochs", "workers_count".

        :return: a context manager for a `tf.data.Dataset` object.
                 when exit the returned context manager, the reader
                 will be closed.
        """
~~~

## Example code
~~~python
from petastorm import make_spark_converter
from petastorm.spark import SparkDatasetConverter
import torch

# specify a cache dir first.
# the dir is used to save materialized spark dataframe files
spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, 'hdfs:/...')

df1 = ... # `df1` is a spark dataframe

# create a converter from `df1`
# it will materialize `df1` to cache dir.
converter1 = make_spark_converter(df1)

# make a tensorflow dataset from `converter1
with converter1.make_tf_dataset(
        batch_size=128, prefetch=2, num_epochs=1, worker_count=1,
        cur_shard=hvd.rank(),
        shard_count=hvd.count()) as dataset:
    # the `dataset` is `tf.data.Dataset` object
    # we can train/evaluate model on `dataset`
    # when exit the with context, the underlying petastorm reader of the dataset will be closed
    ...

# delete the cached files of the dataframe.
converter1.delete()
~~~