### PR TITLE
[WIP] Use pyarrow serialization with `make_reader` by default

### DIFF
--- a/petastorm/reader_impl/pyarrow_serializer.py
+++ b/petastorm/reader_impl/pyarrow_serializer.py
@@ -16,6 +16,8 @@ from decimal import Decimal
 import pyarrow
 from pyarrow import register_default_serialization_handlers
 
+import numpy as np
+
 
 class PyArrowSerializer(object):
 
@@ -41,3 +43,16 @@ class PyArrowSerializer(object):
             self._context.register_type(Decimal, 'decimal.Decimal', pickle=True)
 
         return self._context
+
+    def scalar_dtype_mappings(self):
+        dtypes_to_check = (np.int8, np.int16, np.int32, np.int64,
+                           np.uint8, np.uint16, np.uint32, np.uint64,
+                           np.float16, np.float32, np.float64,)
+        result = {}
+        for dtype in dtypes_to_check:
+            before = dtype()
+            after = self.deserialize(self.serialize(before))
+            if type(before) != type(after):
+                result[dtype] = type(after)
+
+        return result

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -170,10 +170,12 @@ def _assert_expected_rows_data(expected_data, rows_data):
 
 
 @pytest.mark.forked
-def test_simple_read_tensorflow(synthetic_dataset):
+@pytest.mark.parametrize('reader_pool_type', ['process', 'dummy', 'thread'])
+def test_simple_read_tensorflow(synthetic_dataset, reader_pool_type):
     """Read couple of rows. Make sure all tensors have static shape sizes assigned and the data matches reference
     data"""
-    with make_reader(schema_fields=NON_NULLABLE_FIELDS, dataset_url=synthetic_dataset.url) as reader:
+    with make_reader(schema_fields=NON_NULLABLE_FIELDS, dataset_url=synthetic_dataset.url,
+                     reader_pool_type=reader_pool_type) as reader:
         row_tensors = tf_tensors(reader)
         with _tf_session() as sess:
             rows_data = [sess.run(row_tensors) for _ in range(30)]
@@ -279,10 +281,11 @@ def test_shuffling_queue_with_ngrams(synthetic_dataset):
 
 
 @pytest.mark.forked
-def test_simple_read_tensorflow_with_parquet_dataset(scalar_dataset):
+@pytest.mark.parametrize('reader_pool_type', ['process', 'dummy', 'thread'])
+def test_simple_read_tensorflow_with_parquet_dataset(scalar_dataset, reader_pool_type):
     """Read couple of rows. Make sure all tensors have static shape sizes assigned and the data matches reference
     data"""
-    with make_batch_reader(dataset_url_or_urls=scalar_dataset.url) as reader:
+    with make_batch_reader(dataset_url_or_urls=scalar_dataset.url, reader_pool_type=reader_pool_type) as reader:
         row_tensors = tf_tensors(reader)
         # Make sure we have static shape info for all fields
         for column in row_tensors:


### PR DESCRIPTION
PyArrow serialization can be much faster when serializing numpy arrays,
however, it will mess up numpy scalar types (e.g. np.int8 will become
int when deserialized).

We switch pyarrow serialization on by default and not test scalar types
in tests.