### PR TITLE
[WIP] Auto infer schema (including fields shape) from the first row

### DIFF
--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -170,7 +170,7 @@ class ArrowReaderWorker(WorkerBase):
         if all_cols:
             self.publish_func(all_cols)
 
-    def infer_schema_from_first_row(self):
+    def infer_schema_from_a_row(self):
         self._init_dataset()
 
         piece0 = self._split_pieces[0]

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -183,6 +183,7 @@ class ArrowReaderWorker(WorkerBase):
         row0_pdf = piece0_pdf.head(n=1)
         if self._transform_spec:
             row0_pdf = self._transform_spec.func(row0_pdf)
+            column_names = list(row0_pdf.columns)
 
         unischema_fields = []
         for field_name in column_names:

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -250,13 +250,10 @@ def make_batch_reader(dataset_url_or_urls,
     :param infer_schema_from_first_row: Whether to infer schema from the first row data. Only support parquet reader.
         If on, before creating the reader, it will first read one row group to infer the full schema information,
         and the transform spec (if exists) do not need to specify edit_fields/removed_fields.
-        Require:
-         * for all rows (before applying predicates), all values in each field are non-nullable and have
-          the same shape.
-         * Do not support parquet partition column.
-        Turning on this param will address the following two issues:
-          * Auto inferring parquet schema from metadata cannot get shape information.
-          * If there's a preprocessing function, we have to specify edit/removed fields.
+        Require: for all rows (before applying predicates), all values in each field are non-nullable and have the
+        same shape.
+        Turning on this param will address the following two issues: (1) Auto inferring parquet schema from metadata
+        cannot get shape information. (2) If there's a preprocessing function, we have to specify edit/removed fields.
     :return: A :class:`Reader` object
     """
     dataset_url_or_urls = normalize_dataset_url_or_urls(dataset_url_or_urls)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -234,11 +234,11 @@ class SparkDatasetConverter(object):
             raise ValueError('User cannot set dataset_url_or_urls argument.')
 
         if 'transform_spec' in petastorm_reader_kwargs or \
-                'infer_schema_from_first_row' in petastorm_reader_kwargs:
-            raise ValueError('User cannot set transform_spec and infer_schema_from_first_row '
+                'infer_schema_from_a_row' in petastorm_reader_kwargs:
+            raise ValueError('User cannot set transform_spec and infer_schema_from_a_row '
                              'arguments, use `preprocess_fn` argument instead.')
 
-        petastorm_reader_kwargs['infer_schema_from_first_row'] = True
+        petastorm_reader_kwargs['infer_schema_from_a_row'] = True
         if preprocess_fn:
             petastorm_reader_kwargs['transform_spec'] = TransformSpec(preprocess_fn)
 

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -38,6 +38,7 @@ _NUMPY_TO_TF_DTYPES_MAPPING = {
     np.string_: tf.string,
     np.unicode_: tf.string,
     np.str_: tf.string,
+    np.bytes_: tf.string,
     np.bool_: tf.bool,
     Decimal: tf.string,
     np.datetime64: tf.int64,

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -172,11 +172,11 @@ class Unischema(object):
         """Creates an instance of a Unischema object.
 
         :param name: name of the schema
-        :param fields: a list of ``UnischemaField`` instances describing the fields. The order of the fields
-            will be the order from the fields list.
+        :param fields: a list of ``UnischemaField`` instances describing the fields. The order of the fields is
+            not important - they are stored sorted by name internally.
         """
         self._name = name
-        self._fields = OrderedDict([(f.name, f) for f in fields])
+        self._fields = OrderedDict([(f.name, f) for f in sorted(fields, key=lambda t: t.name)])
         # Generates attributes named by the field names as an access syntax sugar.
         for f in fields:
             if not hasattr(self, f.name):

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -172,11 +172,11 @@ class Unischema(object):
         """Creates an instance of a Unischema object.
 
         :param name: name of the schema
-        :param fields: a list of ``UnischemaField`` instances describing the fields. The order of the fields is
-            not important - they are stored sorted by name internally.
+        :param fields: a list of ``UnischemaField`` instances describing the fields. The order of the fields
+            will be the order from the fields list.
         """
         self._name = name
-        self._fields = OrderedDict([(f.name, f) for f in sorted(fields, key=lambda t: t.name)])
+        self._fields = OrderedDict([(f.name, f) for f in fields])
         # Generates attributes named by the field names as an access syntax sugar.
         for f in fields:
             if not hasattr(self, f.name):


### PR DESCRIPTION
## What issues does the PR addresses ?

There're 2 issues in `make_batch_reader`, one is critical and another is less critical but a pain point.

### (Critical) Inferring schema in `make_batch_reader` cannot infer fields' shape information
Because there's no shape information, when make tensorflow dataset from the reader, if we make some tensorflow dataset operations, such as unroll, batch, and reshape field, error may occur. Tensorflow graph operator depends on field shape information heavily.

### (Pain point) The `TransformSpec` need to specify edit/removed fields manually
We hope user can only provide a transform function, and petastorm can automatically infer the result schema from the output pandas dataframe of the transform function.

## The approach in the PR
Add a method `ArrowReaderWorker. infer_schema_from_first_row` which can read a row first and infer the schema from the row. So that we can infer the accurate shape information.
Add a param `infer_schema_from_first_row` into `make_batch_reader` (default off, so won't break API behavior)

**Limitations:**
* for all rows (before applying predicates), require all values in each field non-nullable and having the same shape.

## Test
Unit test to be added. But it is ready for first review.

## Example code

~~~python
import os
import pandas as pd
import sys
import numpy as np
from pyspark.sql.functions import pandas_udf
import tensorflow as tf

from petastorm import make_batch_reader
from petastorm.transform import TransformSpec
from petastorm.spark import make_spark_converter
spark.conf.set('petastorm.spark.converter.parentCacheDirUrl', 'file:/tmp/converter')

data_url = 'file:/tmp/0001'
data_path = '/tmp/t0001'

@pandas_udf('array<float>')
def gen_array(v):
  return v.map(lambda x: np.random.rand(10))

df1 = spark.range(10).withColumn('v', gen_array('id')).repartition(2)
cv1 = make_spark_converter(df1)

# we can auto infer one-dim array shape
with cv1.make_tf_dataset(batch_size=4, num_epochs=1) as dataset:
	iter = dataset.make_one_shot_iterator()
	next_op = iter.get_next()
	with tf.Session() as sess:
		for i in range(3):
			batch = sess.run(next_op)
			print(batch)


def preproc_fn(x):
  # reshape column 'v' to (2, 5) shape.
  x2 = pd.DataFrame({'v': x['v'].map(lambda x: x.reshape((2, 5))), 'id': x['id'] + 10000})
  return x2

# now we can auto infer multi-dim array shape.
with cv1.make_tf_dataset(batch_size=4, preprocess_fn=preproc_fn, num_epochs=1) as dataset:
	iter = dataset.make_one_shot_iterator()
	next_op = iter.get_next()
	with tf.Session() as sess:
		for i in range(3):
			batch = sess.run(next_op)
			print(batch)
~~~

