### PR TITLE
[ML-9743] Address S3 eventually consistency issue on S3-like filesystem

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -417,7 +417,7 @@ def _wait_for_fs_eventually_consistency(url_list):
     all files can be accessed by dbfs fuse.
     This is because of s3 eventually consistency, and the backend of dbfs is s3.
     """
-    _, path_list = get_filesystem_and_path_or_paths(url_list)
+    fs, path_list = get_filesystem_and_path_or_paths(url_list)
     remaining_list = list(path_list)
     new_remaining_list = []
 
@@ -429,11 +429,11 @@ def _wait_for_fs_eventually_consistency(url_list):
         return
 
     logger.debug('Because of filesystem eventually consistency, waiting several seconds until '
-                 'these files become accessible: ', ','.join(remaining_list))
+                 'these files become accessible: %s', ','.join(remaining_list))
 
     for _ in range(wait_seconds):
         for path in remaining_list:
-            if not os.path.exists(path):
+            if not fs.exists(path):
                 new_remaining_list.append(path)
         remaining_list = new_remaining_list
         new_remaining_list = []

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -158,7 +158,7 @@ class SparkDatasetConverter(object):
     """
 
     PARENT_CACHE_DIR_URL_CONF = 'petastorm.spark.converter.parentCacheDirUrl'
-    WAIT_FS_EVENTUALLY_CONSISTENCY_SECONDS = 'petastorm.spark.converter.fsEventuallyConsistencySecs'
+    WAIT_FS_EVENTUALLY_CONSISTENCY_SECONDS = 'petastorm.spark.converter.fsEventuallyConsistencyWaitSecs'
 
     def __init__(self, cache_dir_url, parquet_file_url_list, dataset_size):
         """

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -19,6 +19,7 @@ import datetime
 import uuid
 import logging
 import os
+import time
 import warnings
 from distutils.version import LooseVersion
 
@@ -432,6 +433,12 @@ def _databricks_wait_for_s3_consistency(url_list):
                 new_remaining_list.append(path)
         remaining_list = new_remaining_list
         new_remaining_list = []
+
+        if not remaining_list:
+            # all files can be accessed by dbfs fuse
+            return
+
+        time.sleep(1)
 
     if remaining_list:
         raise RuntimeError('These files cannot be synced after waiting 30 seconds: {path_list}'.format(

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -493,7 +493,7 @@ def _wait_file_available(url_list):
     wait_seconds = int(wait_seconds)
     if wait_seconds <= 0:
         return
-    logger.debug('Waiting some seconds until all parquet-store files appear at urls {url_list}', ','.join(url_list))
+    logger.debug('Waiting some seconds until all parquet-store files appear at urls %s', ','.join(url_list))
 
     def wait_for_file(path):
         end_time = time.time() + wait_seconds

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -489,7 +489,7 @@ def _wait_file_available(url_list):
     """
     fs, path_list = get_filesystem_and_path_or_paths(url_list)
     wait_seconds = _get_spark_session().conf \
-        .get(SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF, '0')
+        .get(SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF, '30')
     wait_seconds = int(wait_seconds)
     if wait_seconds <= 0:
         return

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -25,7 +25,6 @@ from distutils.version import LooseVersion
 from multiprocessing.pool import ThreadPool
 
 from pyarrow import LocalFileSystem
-from pyspark.ml.common import _java2py
 from pyspark.sql.session import SparkSession
 from six.moves.urllib.parse import urlparse
 
@@ -502,6 +501,6 @@ def make_spark_converter(
     spark_df = spark.read.parquet(dataset_cache_dir_url)
 
     dataset_size = spark_df.count()
-    parquet_file_url_list = _java2py(spark.sparkContext, spark_df._jdf.inputFiles())
+    parquet_file_url_list = list(spark_df._jdf.inputFiles())
 
     return SparkDatasetConverter(dataset_cache_dir_url, parquet_file_url_list, dataset_size)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -505,7 +505,8 @@ def _wait_for_fs_eventually_consistency(url_list):
             if elapsed > wait_seconds:
                 return False
 
-    with ThreadPool(64) as pool:
+    pool = ThreadPool(64)
+    try:
         async_results = [pool.apply_async(wait_on_file, (path,)) for path in path_list]
         failed_file_list = []
         for i in range(len(path_list)):
@@ -515,6 +516,9 @@ def _wait_for_fs_eventually_consistency(url_list):
         if failed_file_list:
             raise RuntimeError('These files cannot be synced after waiting {wait} seconds: {path_list}'
                                .format(wait=wait_seconds, path_list=','.join(failed_file_list)))
+    finally:
+        pool.close()
+        pool.join()
 
 
 def make_spark_converter(

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -361,6 +361,7 @@ class TorchDatasetContextManager(object):
     def __enter__(self):
         from petastorm.pytorch import DataLoader
 
+        _wait_file_available(self.parquet_file_url_list)
         self.reader = make_batch_reader(self.parquet_file_url_list,
                                         **self.petastorm_reader_kwargs)
         self.loader = DataLoader(reader=self.reader, batch_size=self.batch_size)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -506,7 +506,7 @@ def _wait_file_available(url_list):
     pool = ThreadPool(64)
     try:
         results = pool.map(wait_for_file, path_list)
-        failed_list = [url for url, result in zip(url_list, results) if result]
+        failed_list = [url for url, result in zip(url_list, results) if not result]
         if failed_list:
             raise RuntimeError('Timeout while waiting for all parquet-store files to appear at urls {failed_list},'
                                'Please check whether these files were saved successfully when materializing dataframe.'

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -323,7 +323,7 @@ def test_wait_for_fs_eventually_consistency(test_ctx):
 
     # 2. test one file does not exists. Raise error.
     os.remove(file2_path)
-    with pytest.raises(RuntimeError, match='These files cannot be synced after waiting 30 seconds'):
+    with pytest.raises(RuntimeError, match='These files cannot be synced after waiting'):
         _wait_for_fs_eventually_consistency(url_list)
 
     # 3. test one file accessible after 1 second.

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -429,7 +429,7 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, test_ctx
     assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
 
 
-def test_wait_for_fs_eventually_consistency(test_ctx):
+def test_wait_file_available(test_ctx):
     pq_dir = os.path.join(test_ctx.tempdir, 'test_ev')
     os.makedirs(pq_dir)
     file1_path = os.path.join(pq_dir, 'file1')
@@ -450,7 +450,8 @@ def test_wait_for_fs_eventually_consistency(test_ctx):
 
     # 2. test one file does not exists. Raise error.
     os.remove(file2_path)
-    with pytest.raises(RuntimeError, match='These files cannot be synced after waiting'):
+    with pytest.raises(RuntimeError,
+                       match='Timeout while waiting for all parquet-store files to appear at urls'):
         _wait_file_available(url_list)
 
     # 3. test one file accessible after 1 second.

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -305,8 +305,8 @@ def test_horovod_rank_compatibility(test_ctx):
 def test_wait_for_fs_eventually_consistency(test_ctx):
     pq_dir = os.path.join(test_ctx.tempdir, 'test_ev')
     os.makedirs(pq_dir)
-    file1_path = os.path.join(test_ctx.tempdir, 'file1')
-    file2_path = os.path.join(test_ctx.tempdir, 'file2')
+    file1_path = os.path.join(pq_dir, 'file1')
+    file2_path = os.path.join(pq_dir, 'file2')
     url1 = 'file://' + file1_path.replace(os.sep, '/')
     url2 = 'file://' + file2_path.replace(os.sep, '/')
 
@@ -334,5 +334,3 @@ def test_wait_for_fs_eventually_consistency(test_ctx):
     threading.Thread(target=delay_create_file2()).start()
 
     _wait_for_fs_eventually_consistency(url_list)
-
-

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -420,7 +420,7 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, test_ctx
         peta_args['cur_shard'] == 1 and \
         peta_args['shard_count'] == SHARD_COUNT and \
         peta_args['num_epochs'] is None and \
-        peta_args['workers_count'] == 44
+        peta_args['workers_count'] == 4
 
     # Test default value overridden arguments.
     with conv.make_torch_dataloader(num_epochs=1, workers_count=2) as _:

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -415,12 +415,12 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, test_ctx
     with conv.make_torch_dataloader(reader_pool_type='dummy', cur_shard=1,
                                     shard_count=SHARD_COUNT) as _:
         pass
-    peta_args = mock_torch_make_batch_reader.call_args[1]
+    peta_args = mock_torch_make_batch_reader.call_args.kwargs
     assert peta_args['reader_pool_type'] == 'dummy' and \
         peta_args['cur_shard'] == 1 and \
         peta_args['shard_count'] == SHARD_COUNT and \
         peta_args['num_epochs'] is None and \
-        ('workers_count' not in peta_args)
+        peta_args['workers_count'] == 44
 
     # Test default value overridden arguments.
     with conv.make_torch_dataloader(num_epochs=1, workers_count=2) as _:


### PR DESCRIPTION
For some filesystem like aws S3, there's an eventually consistency issue: after we materialized dataframe as parquet files, when use petastorm reader, the file may not be available immediately. We need wait at most 30 seconds to make sure all files are available. This is caused by S3 list operation eventually consistency.
