### PR TITLE
[ML-10156] Fix array type field inferred shape

### DIFF
--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -44,11 +44,6 @@ from petastorm.spark.spark_dataset_converter import (
     _check_rank_and_size_consistent_with_horovod, _make_sub_dir_url,
     register_delete_dir_handler)
 
-try:
-    from mock import mock
-except ImportError:
-    from unittest import mock
-
 
 class TestContext(object):
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -120,7 +120,6 @@ def test_array_field(test_ctx):
     @pandas_udf('array<float>')
     def gen_array(v):
         return v.map(lambda x: np.random.rand(10))
-
     df1 = test_ctx.spark.range(10).withColumn('v', gen_array('id')).repartition(2)
     cv1 = make_spark_converter(df1)
     # we can auto infer one-dim array shape
@@ -129,8 +128,7 @@ def test_array_field(test_ctx):
         next_op = tf_iter.get_next()
         with tf.Session() as sess:
             batch1 = sess.run(next_op)
-        
-        assert batch1.shape == (4, 10)
+        assert batch1.v.shape == (4, 10)
 
 
 def test_delete(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -16,9 +16,12 @@ import os
 import subprocess
 import sys
 import tempfile
+import pyarrow
 import pytest
 import numpy as np
 import tensorflow as tf
+
+from distutils.version import LooseVersion
 
 try:
     from mock import mock
@@ -116,6 +119,8 @@ def test_primitive(test_ctx):
     assert np.object_ == ts.bin_col.dtype.type
 
 
+@pytest.mark.skipif(LooseVersion(pyarrow.__version__) >= LooseVersion('0.15'),
+                    reason="Spark 2.x is not compatible with pyarrow>=0.15")
 def test_array_field(test_ctx):
     @pandas_udf('array<float>')
     def gen_array(v):

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -284,9 +284,15 @@ def test_simple_read_tensorflow_with_parquet_dataset(scalar_dataset):
     data"""
     with make_batch_reader(dataset_url_or_urls=scalar_dataset.url) as reader:
         row_tensors = tf_tensors(reader)
+        row_tensors_dict = row_tensors._asdict()
         # Make sure we have static shape info for all fields
-        for column in row_tensors:
-            assert column.get_shape().as_list() == [None]
+        for column_name in row_tensors_dict:
+            column = row_tensors_dict[column_name]
+            column_shape = column.get_shape().as_list()
+            if column_name == 'int_fixed_size_list':
+                assert column_shape == [None, None]
+            else:
+                assert column_shape == [None]
 
         with _tf_session() as sess:
             for _ in range(2):

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -322,11 +322,13 @@ class Unischema(object):
         for column_name in arrow_schema.names:
             arrow_field = arrow_schema.field_by_name(column_name)
             field_type = arrow_field.type
+            field_shape = ()
             if isinstance(field_type, ListType):
                 if isinstance(field_type.value_type, ListType) or isinstance(field_type.value_type, pyStructType):
                     warnings.warn('[ARROW-1644] Ignoring unsupported structure %r for field %r'
                                   % (field_type, column_name))
                     continue
+                field_shape = (None,)
             try:
                 np_type = _numpy_and_codec_from_arrow_type(field_type)
             except ValueError:
@@ -336,7 +338,7 @@ class Unischema(object):
                     continue
                 else:
                     raise
-            unischema_fields.append(UnischemaField(column_name, np_type, (), None, arrow_field.nullable))
+            unischema_fields.append(UnischemaField(column_name, np_type, field_shape, None, arrow_field.nullable))
         return Unischema('inferred_schema', unischema_fields)
 
 


### PR DESCRIPTION
I set the inferred shape for array type field to be `(None,)` instead of `()`.
This will address issues on tensorflow dataset.

Test code:
```
import os
import pandas as pd
import sys
import numpy as np
from pyspark.sql.functions import pandas_udf
import tensorflow as tf

from petastorm import make_batch_reader
from petastorm.transform import TransformSpec
from petastorm.spark import make_spark_converter
spark.conf.set('petastorm.spark.converter.parentCacheDirUrl', 'file:/tmp/converter')

data_url = 'file:/tmp/0001'
data_path = '/tmp/t0001'

@pandas_udf('array<float>')
def gen_array(v):
  return v.map(lambda x: np.random.rand(10))

df1 = spark.range(10).withColumn('v', gen_array('id')).repartition(2)
cv1 = make_spark_converter(df1)

# we can auto infer one-dim array shape
with cv1.make_tf_dataset(batch_size=4, num_epochs=1) as dataset:
	iter = dataset.make_one_shot_iterator()
	next_op = iter.get_next()
	with tf.Session() as sess:
		for i in range(3):
			batch = sess.run(next_op)
			print(batch)
```

**Before**
Raise error like:
```
2020-03-25 12:02:26.230197: W tensorflow/core/framework/op_kernel.cc:1651] OP_REQUIRES failed at tensor_slice_dataset_op.cc:193 : Invalid argument: Incompatible shapes at component 1: expected [10] but got [].
2020-03-25 12:02:26.231091: W tensorflow/core/framework/op_kernel.cc:1651] OP_REQUIRES failed at tensor_slice_dataset_op.cc:193 : Invalid argument: Incompatible shapes at component 1: expected [10] but got [].
Traceback (most recent call last):
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1365, in _do_call
    return fn(*args)
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1350, in _run_fn
    target_list, run_metadata)
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1443, in _call_tf_sessionrun
    run_metadata)
tensorflow.python.framework.errors_impl.InvalidArgumentError: {{function_node __inference_Dataset_flat_map_from_tensor_slices_45}} Incompatible shapes at component 1: expected [10] but got [].
	 [[{{node TensorSliceDataset}}]]
	 [[IteratorGetNext]]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 956, in run
    run_metadata_ptr)
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1180, in _run
    feed_dict_tensor, options, run_metadata)
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1359, in _do_run
    run_metadata)
  File "/Users/weichenxu/anaconda3/lib/python3.7/site-packages/tensorflow_core/python/client/session.py", line 1384, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.InvalidArgumentError:  Incompatible shapes at component 1: expected [10] but got [].
	 [[{{node TensorSliceDataset}}]]
	 [[IteratorGetNext]]
```

**After**
Code works well.