### PR TITLE
Update Spark Converter API section in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,8 +225,8 @@ The minimalist example below assumes the definition of a ``Net`` class and
                                 transform_spec=transform), batch_size=1000) as test_loader:
         test(model, device, test_loader)
 
-Spark Converter API
--------------------
+Spark Dataset Converter API
+---------------------------
 
 Spark converter API simplifies the data conversion from Spark to TensorFlow or PyTorch.
 The input Spark DataFrame is first materialized in the parquet format and then loaded as
@@ -263,8 +263,9 @@ Spark DataFrame containing a feature column followed by a label column.
     converter1.delete()
 
 The minimalist example below assumes the definition of a ``Net`` class and
-``train`` and ``test`` functions, and a Spark DataFrame containing a feature
-column followed by a label column.
+``train`` and ``test`` functions, included in
+`pytorch_example.py <https://github.com/uber/petastorm/blob/master/examples/mnist/pytorch_example.py>`_,
+and a Spark DataFrame containing a feature column followed by a label column.
 
 .. code-block:: python
 
@@ -272,18 +273,20 @@ column followed by a label column.
 
     spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, 'hdfs:/...')
 
-    df1 = ... # `df1` is a spark dataframe
+    df_train, df_test = ... # `df_train` and `df_test` are spark dataframes
     model = Net()
 
-    converter1 = make_spark_converter(df1)
+    converter_train = make_spark_converter(df_train)
+    converter_test = make_spark_converter(df_test)
 
-    with converter1.make_torch_dataloader() as dataloader:
+    with converter_train.make_torch_dataloader() as dataloader:
         train(model, dataloader, ...)
 
-    with converter1.make_torch_dataloader() as dataloader:
+    with converter_test.make_torch_dataloader() as dataloader:
         test(model, dataloader, ...)
 
-    converter1.delete()
+    converter_train.delete()
+    converter_test.delete()
 
 
 PySpark and SQL

--- a/README.rst
+++ b/README.rst
@@ -299,8 +299,8 @@ and a Spark DataFrame containing a feature column followed by a label column.
     converter_test.delete()
 
 
-PySpark and SQL
----------------
+Analyzing petastorm datasets using PySpark and SQL
+--------------------------------------------------
 
 A Petastorm dataset can be read into a Spark DataFrame using PySpark, where you can
 use a wide range of Spark tools to analyze and manipulate the dataset.

--- a/README.rst
+++ b/README.rst
@@ -244,14 +244,14 @@ Spark DataFrame containing a feature column followed by a label column.
     # the dir is used to save materialized spark dataframe files
     spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, 'hdfs:/...')
 
-    df1 = ... # `df1` is a spark dataframe
+    df = ... # `df` is a spark dataframe
 
-    # create a converter from `df1`
-    # it will materialize `df1` to cache dir.
-    converter1 = make_spark_converter(df1)
+    # create a converter from `df`
+    # it will materialize `df` to cache dir.
+    converter = make_spark_converter(df)
 
-    # make a tensorflow dataset from `converter1
-    with converter1.make_tf_dataset() as dataset:
+    # make a tensorflow dataset from `converter`
+    with converter.make_tf_dataset() as dataset:
         # the `dataset` is `tf.data.Dataset` object
         # dataset transformation can be done if needed
         dataset = dataset.map(...)
@@ -260,7 +260,7 @@ Spark DataFrame containing a feature column followed by a label column.
         # when exiting the context, the reader of the dataset will be closed
 
     # delete the cached files of the dataframe.
-    converter1.delete()
+    converter.delete()
 
 The minimalist example below assumes the definition of a ``Net`` class and
 ``train`` and ``test`` functions, included in
@@ -271,20 +271,30 @@ and a Spark DataFrame containing a feature column followed by a label column.
 
     from petastorm.spark import SparkDatasetConverter, make_spark_converter
 
+    # specify a cache dir first.
+    # the dir is used to save materialized spark dataframe files
     spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, 'hdfs:/...')
 
     df_train, df_test = ... # `df_train` and `df_test` are spark dataframes
     model = Net()
 
+    # create a converter_train from `df_train`
+    # it will materialize `df_train` to cache dir. (the same for df_test)
     converter_train = make_spark_converter(df_train)
     converter_test = make_spark_converter(df_test)
 
-    with converter_train.make_torch_dataloader() as dataloader:
-        train(model, dataloader, ...)
+    # make a pytorch dataloader from `converter_train`
+    with converter_train.make_torch_dataloader() as dataloader_train:
+        # the `dataloader_train` is `torch.utils.data.DataLoader` object
+        # we can train model using the `dataloader_train`
+        train(model, dataloader_train, ...)
+        # when exiting the context, the reader of the dataset will be closed
 
-    with converter_test.make_torch_dataloader() as dataloader:
-        test(model, dataloader, ...)
+    # the same for `converter_test`
+    with converter_test.make_torch_dataloader() as dataloader_test:
+        test(model, dataloader_test, ...)
 
+    # delete the cached files of the dataframes.
     converter_train.delete()
     converter_test.delete()
 

--- a/README.rst
+++ b/README.rst
@@ -269,7 +269,6 @@ column followed by a label column.
 .. code-block:: python
 
     from petastorm.spark import SparkDatasetConverter, make_spark_converter
-    import tensorflow as tf
 
     spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, 'hdfs:/...')
 


### PR DESCRIPTION
The "Spark Converter API" section now contains minimalist examples of Spark -> Tensorflow and Spark -> PyTorch.
I also edited the section "PySpark and SQL" to make it better connected with the preceding section.