### PR TITLE
[ML-10160] Refine Spark dataset converter warning logs.

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -425,7 +425,7 @@ def _check_parent_cache_dir_url(dir_url):
     if 'DATABRICKS_RUNTIME_VERSION' in os.environ and not _is_spark_local_mode():
         if isinstance(fs, LocalFileSystem):
             # User need to use dbfs fuse URL.
-            if dir_path.startswith('/dbfs/'):
+            if not dir_path.startswith('/dbfs/'):
                 raise ValueError(
                     "You must specify a dbfs fuse path for {conf}, like: 'file:/dbfs/path/to/cache_dir'"
                     .format(conf=SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -543,7 +543,7 @@ def _check_dataset_file_median_size(url_list):
         mid_index = len(file_size_list) // 2
         median_size = sorted(file_size_list)[mid_index]
         if median_size < 50 * 1024 * 1024:
-            logger.warning('The median size ({%d}) of these parquet files ({%s}) is too small.'
+            logger.warning('The median size (%d) of these parquet files (%s) is too small.'
                            'Increase file sizes by repartition or coalesce spark dataframe, which '
                            'will help improve performance.', median_size, ','.join(url_list))
 

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -421,13 +421,14 @@ def _check_parent_cache_dir_url(dir_url):
     Check dir url whether is suitable to be used as parent cache directory.
     """
     _check_url(dir_url)
-    parsed = urlparse(dir_url)
+    fs, dir_path = get_filesystem_and_path_or_paths(dir_url)
     if 'DATABRICKS_RUNTIME_VERSION' in os.environ and not _is_spark_local_mode():
-        # User need to use dbfs fuse URL.
-        if parsed.scheme.lower() != 'file' or not parsed.path.startswith('/dbfs/'):
-            raise ValueError(
-                "You must specify a dbfs fuse path for {conf}, like: 'file:/dbfs/path/to/cache_dir'"
-                .format(conf=SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
+        if isinstance(fs, LocalFileSystem):
+            # User need to use dbfs fuse URL.
+            if dir_path.startswith('/dbfs/'):
+                raise ValueError(
+                    "You must specify a dbfs fuse path for {conf}, like: 'file:/dbfs/path/to/cache_dir'"
+                    .format(conf=SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
 
 
 def _make_sub_dir_url(dir_url, name):

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -412,6 +412,12 @@ def _check_url(dir_url):
             'ERROR! A scheme-less directory url ({}) is no longer supported. '
             'Please prepend "file://" for local filesystem.'.format(dir_url))
 
+    if 'DATABRICKS_RUNTIME_VERSION' in os.environ:
+        if parsed.scheme.lower() != 'file' or not parsed.path.startswith('/dbfs/'):
+            raise ValueError(
+                "You must specify a dbfs fuse path for {conf}, like: 'file:/dbfs/path/to/cache_dir'"
+                .format(conf=SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
+
 
 def _make_sub_dir_url(dir_url, name):
     parsed = urlparse(dir_url)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -437,9 +437,11 @@ def _check_parent_cache_dir_url(dir_url):
         if isinstance(fs, LocalFileSystem):
             # User need to use dbfs fuse URL.
             if not dir_path.startswith('/dbfs/'):
-                raise ValueError(
-                    "You must specify a dbfs fuse path for {conf}, like: 'file:/dbfs/path/to/cache_dir'"
-                    .format(conf=SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
+                logger.warning(
+                    "Usually, when running on databricks spark cluster, you should specify a dbfs fuse path "
+                    "for %s, like: 'file:/dbfs/path/to/cache_dir', otherwise, you should mount NFS to this "
+                    "directory '%s' on all nodes of the cluster, e.g. using EFS.",
+                    SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, dir_url)
 
 
 def _make_sub_dir_url(dir_url, name):

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -543,10 +543,9 @@ def _check_dataset_file_median_size(url_list):
         mid_index = len(file_size_list) // 2
         median_size = sorted(file_size_list)[mid_index]
         if median_size < 50 * 1024 * 1024:
-            logger.warning('The median size ({ms}) of these parquet files ({url_list}) is too small.'
+            logger.warning('The median size ({%d}) of these parquet files ({%s}) is too small.'
                            'Increase file sizes by repartition or coalesce spark dataframe, which '
-                           'will help improve performance.'
-                           .format(ms=median_size, url_list=','.join(url_list)))
+                           'will help improve performance.', median_size, ','.join(url_list))
 
 
 def make_spark_converter(

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -496,7 +496,7 @@ def test_wait_file_available(test_ctx):
     _wait_file_available(url_list)
 
 
-def test_check_dataset_file_median_size(test_ctx):
+def test_check_dataset_file_median_size(test_ctx, caplog):
     file_size_map = {
         '/a/b/01.parquet': 50,
         '/a/b/02.parquet': 70,
@@ -507,14 +507,14 @@ def test_check_dataset_file_median_size(test_ctx):
     with mock.patch('os.path.getsize') as mock_path_get_size:
         mock_path_get_size.side_effect = lambda p: file_size_map[p]
         url_list = ['file://' + path for path in file_size_map.keys()]
-        with patch_logger('petastorm.spark.spark_dataset_converter') as output:
-            _check_dataset_file_median_size(url_list)
-            assert 'The median size (65) of these parquet files' in output.getvalue()
+        caplog.clear()
+        _check_dataset_file_median_size(url_list)
+        assert 'The median size (65) of these parquet files' in '\n'.join([r.message for r in caplog.records])
         for k in file_size_map:
             file_size_map[k] *= (1024 * 1024)
-        with patch_logger('petastorm.spark.spark_dataset_converter') as output:
-            _check_dataset_file_median_size(url_list)
-            assert 'The median size (68157440) of these parquet files' not in output.getvalue()
+        caplog.clear()
+        _check_dataset_file_median_size(url_list)
+        assert 'The median size (68157440) of these parquet files' not in '\n'.join([r.message for r in caplog.records])
 
 
 @mock.patch.dict(os.environ, {'DATABRICKS_RUNTIME_VERSION': '7.0'}, clear=True)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
-import logging
 import numpy as np
 import os
 import pytest
@@ -24,7 +22,6 @@ import tensorflow as tf
 import threading
 import time
 
-from six import StringIO
 from six.moves.urllib.parse import urlparse
 
 try:

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -64,19 +64,6 @@ class TestContext(object):
         self.spark.stop()
 
 
-@contextlib.contextmanager
-def patch_logger(name):
-    """patch logger and give an output"""
-    io_out = StringIO()
-    log = logging.getLogger(name)
-    handler = logging.StreamHandler(io_out)
-    log.addHandler(handler)
-    try:
-        yield io_out
-    finally:
-        log.removeHandler(handler)
-
-
 @pytest.fixture(scope='module')
 def test_ctx():
     ctx = TestContext()

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 import os
+import pytest
 import subprocess
 import sys
 import tempfile
+import time
+import threading
 
 import numpy as np
-import pytest
 import tensorflow as tf
+
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
                                FloatType, IntegerType, LongType, ShortType,
@@ -33,7 +36,7 @@ from petastorm.spark import (SparkDatasetConverter, make_spark_converter,
 from petastorm.spark.spark_dataset_converter import (
     _check_url, _get_horovod_rank_and_size, _get_parent_cache_dir_url,
     _check_rank_and_size_consistent_with_horovod, _make_sub_dir_url,
-    register_delete_dir_handler)
+    register_delete_dir_handler, _wait_file_available)
 
 try:
     from mock import mock
@@ -51,6 +54,7 @@ class TestContext(object):
         self.tempdir = tempfile.mkdtemp('_spark_converter_test')
         self.temp_url = 'file://' + self.tempdir.replace(os.sep, '/')
         self.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, self.temp_url)
+        self.spark.conf.set(SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF, '2')
 
     def tear_down(self):
         self.spark.stop()
@@ -411,15 +415,50 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, test_ctx
     with conv.make_torch_dataloader(reader_pool_type='dummy', cur_shard=1,
                                     shard_count=SHARD_COUNT) as _:
         pass
-    peta_args = mock_torch_make_batch_reader.call_args[1]
+    peta_args = mock_torch_make_batch_reader.call_args.kwargs
     assert peta_args['reader_pool_type'] == 'dummy' and \
         peta_args['cur_shard'] == 1 and \
         peta_args['shard_count'] == SHARD_COUNT and \
         peta_args['num_epochs'] is None and \
-        ('workers_count' not in peta_args)
+        peta_args['workers_count'] == 4
 
     # Test default value overridden arguments.
     with conv.make_torch_dataloader(num_epochs=1, workers_count=2) as _:
         pass
     peta_args = mock_torch_make_batch_reader.call_args[1]
     assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
+
+
+def test_wait_file_available(test_ctx):
+    pq_dir = os.path.join(test_ctx.tempdir, 'test_ev')
+    os.makedirs(pq_dir)
+    file1_path = os.path.join(pq_dir, 'file1')
+    file2_path = os.path.join(pq_dir, 'file2')
+    url1 = 'file://' + file1_path.replace(os.sep, '/')
+    url2 = 'file://' + file2_path.replace(os.sep, '/')
+
+    url_list = [url1, url2]
+
+    def create_file(p):
+        with open(p, 'w'):
+            pass
+
+    # 1. test all files exists.
+    create_file(file1_path)
+    create_file(file2_path)
+    _wait_file_available(url_list)
+
+    # 2. test one file does not exists. Raise error.
+    os.remove(file2_path)
+    with pytest.raises(RuntimeError,
+                       match='Timeout while waiting for all parquet-store files to appear at urls'):
+        _wait_file_available(url_list)
+
+    # 3. test one file accessible after 1 second.
+    def delay_create_file2():
+        time.sleep(1)
+        create_file(file2_path)
+
+    threading.Thread(target=delay_create_file2()).start()
+
+    _wait_file_available(url_list)


### PR DESCRIPTION
* Warn users if the intermediate file sizes are too small (<50mb)
* Warn users if set wrong parent cache dir. (Only in databricks environment)