### PR TITLE
Replace deprecated Schema.add_metadata with Schema.with_metadata call.

### DIFF
--- a/petastorm/compat.py
+++ b/petastorm/compat.py
@@ -64,3 +64,17 @@ def compat_make_parquet_piece(path, open_file_func, **kwargs):
     else:
         return pq.ParquetDatasetPiece(path, open_file_func=open_file_func,  # pylint: disable=unexpected-keyword-arg
                                       **kwargs)
+
+
+def compat_with_metadata(schema, metadata):
+    if _PYARROW_BEFORE_015:
+        return schema.add_metadata(metadata)
+    else:
+        return schema.with_metadata(metadata)
+
+
+def compat_schema_field(schema, name):
+    if _PYARROW_BEFORE_013:
+        return schema.field_by_name(name)
+    else:
+        return schema.field(name)

--- a/petastorm/tests/conftest.py
+++ b/petastorm/tests/conftest.py
@@ -75,8 +75,8 @@ def maybe_cached_dataset(config, name, generating_func):
             dataset = generating_func()
             config.cache.set(cache_key, b64encode(pickle.dumps(dataset)).decode('ascii'))
         else:
-            logger.warn('CAUTION: %s HAS BEEN USED. USING %s CACHED TEST DATASET! MAYBE STALE!',
-                        _CACHE_FAKE_DATASET_OPTION, name)
+            logger.warning('CAUTION: %s HAS BEEN USED. USING %s CACHED TEST DATASET! MAYBE STALE!',
+                           _CACHE_FAKE_DATASET_OPTION, name)
     else:
         dataset = generating_func()
 
@@ -110,6 +110,7 @@ def scalar_dataset(request, tmpdir_factory):
 @pytest.fixture(scope="session")
 def many_columns_non_petastorm_dataset(request, tmpdir_factory):
     """This dataset has 1000 columns. All of the same int32 type."""
+
     def _dataset_no_cache():
         path = tmpdir_factory.mktemp("data").strpath
         url = 'file://' + path

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -29,7 +29,7 @@ from pyarrow.lib import ListType
 from pyarrow.lib import StructType as pyStructType
 from six import string_types
 
-from petastorm.compat import compat_get_metadata
+from petastorm.compat import compat_get_metadata, compat_schema_field
 
 # _UNISCHEMA_FIELD_ORDER available values are 'preserve_input_order' or 'alphabetical'
 # Current default behavior is 'preserve_input_order', the legacy behavior is 'alphabetical', which is deprecated and
@@ -331,7 +331,7 @@ class Unischema(object):
             unischema_fields.append(UnischemaField(partition.name, numpy_dtype, (), None, False))
 
         for column_name in arrow_schema.names:
-            arrow_field = arrow_schema.field_by_name(column_name)
+            arrow_field = compat_schema_field(arrow_schema, column_name)
             field_type = arrow_field.type
             field_shape = ()
             if isinstance(field_type, ListType):

--- a/petastorm/utils.py
+++ b/petastorm/utils.py
@@ -22,7 +22,7 @@ import pyarrow
 from future.utils import raise_with_traceback
 from pyarrow.filesystem import LocalFileSystem
 
-from petastorm.compat import compat_get_metadata
+from petastorm.compat import compat_get_metadata, compat_with_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def add_to_dataset_metadata(dataset, key, value):
     # base_schema.metadata may be None, e.g.
     metadata_dict = base_schema.metadata or dict()
     metadata_dict[key] = value
-    schema = base_schema.add_metadata(metadata_dict)
+    schema = compat_with_metadata(base_schema, metadata_dict)
 
     with dataset.fs.open(common_metadata_file_path, 'wb') as metadata_file:
         pyarrow.parquet.write_metadata(schema, metadata_file)


### PR DESCRIPTION
No functionality change as we can see from:
```python
    def add_metadata(self, metadata):
        warnings.warn("The 'add_metadata' method is deprecated, use "
                      "'with_metadata' instead", FutureWarning, stacklevel=2)
        return self.with_metadata(metadata)
```

Our CI does not test all pyarrow versions (just 0.12.1 and 0.15.1), so tried locally 0.13, 0.14 and 0.15)