### PR TITLE
Use parquet.summary.metadata.level to control _summary file creation.

### DIFF
--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -28,6 +28,7 @@ from petastorm.compat import compat_get_metadata, compat_make_parquet_piece
 from petastorm.etl.legacy import depickle_legacy_package_name_compatible
 from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths
 from petastorm.unischema import Unischema
+from packaging import version
 
 logger = logging.getLogger(__name__)
 
@@ -137,9 +138,18 @@ def _init_spark(spark, current_spark_config, row_group_size_mb=None, use_summary
     Initializes spark and hdfs config with necessary options for petastorm datasets
     before running the spark job.
     """
+
+    # It's important to keep pyspark import local because when placed at the top level it somehow messes up with
+    # namedtuple serialization code and we end up getting UnischemaFields objects depickled without overriden __eq__
+    # and __hash__ methods.
+    import pyspark
+    _PYSPARK_BEFORE_24 = version.parse(pyspark.__version__) < version.parse('2.4')
+
     hadoop_config = spark.sparkContext._jsc.hadoopConfiguration()
 
     # Store current values so we can restore them later
+    current_spark_config['parquet.summary.metadata.level'] = \
+        hadoop_config.get('parquet.summary.metadata.level')
     current_spark_config['parquet.enable.summary-metadata'] = \
         hadoop_config.get('parquet.enable.summary-metadata')
     current_spark_config['parquet.summary.metadata.propagate-errors'] = \
@@ -151,7 +161,11 @@ def _init_spark(spark, current_spark_config, row_group_size_mb=None, use_summary
     current_spark_config['parquet.block.size'] = \
         hadoop_config.get('parquet.block.size')
 
-    hadoop_config.setBoolean('parquet.enable.summary-metadata', use_summary_metadata)
+    if _PYSPARK_BEFORE_24:
+        hadoop_config.setBoolean("parquet.enable.summary-metadata", use_summary_metadata)
+    else:
+        hadoop_config.set('parquet.summary.metadata.level', "ALL" if use_summary_metadata else "NONE")
+
     # Our atg fork includes https://github.com/apache/parquet-mr/pull/502 which creates this
     # option. This forces a job to fail if the summary metadata files cannot be created
     # instead of just having them fail to be created silently

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -95,13 +95,14 @@ def _randomize_row(id_num):
     return row_dict
 
 
-def create_test_dataset(tmp_url, rows, num_files=2, spark=None):
+def create_test_dataset(tmp_url, rows, num_files=2, spark=None, use_summary_metadata=False):
     """
     Creates a test dataset under tmp_dir, with rows and num_files that has TestSchema.
     :param tmp_url: The URL of the temp directory to store the test dataset in.
     :param rows: The number of rows for the dataset.
     :param num_files: The number of files to partition the data between.
     :param spark: An optional spark session to use
+    :param use_summary_metadata: If True, _metadata file will be created.
     :return: A list of the dataset dictionary.
     """
 
@@ -116,7 +117,7 @@ def create_test_dataset(tmp_url, rows, num_files=2, spark=None):
         shutdown = True
     spark_context = spark.sparkContext
 
-    with materialize_dataset(spark, tmp_url, TestSchema):
+    with materialize_dataset(spark, tmp_url, TestSchema, use_summary_metadata=use_summary_metadata):
         id_rdd = spark_context.parallelize(rows, numSlices=40)
 
         # Make up some random data and store it for referencing in the tests

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -67,7 +67,7 @@ class UnischemaField(namedtuple('UnischemaField', ['name', 'numpy_dtype', 'shape
         """Comparing field objects via default namedtuple __repr__ representation doesn't work due to
         codec object ID changing when unpickled.
 
-        Instead, compare all field attributes, but only codec type.
+        Instead, compare all field attributes, except for codec type.
 
         Future: Give codec a mime identifier.
         """


### PR DESCRIPTION
Starting spark 2.4, "parquet.enable.summary-metadata" is deprecated and "parquet.summary.metadata.level" should be used to control creation of
`_summary` file. Updated the code to set
`parquet.summary.metadata.level=ALL` is petastorm `use_summary_metadata=True`
and `parquet.summary.metadata.level=NONE` otherwise.