### PR TITLE
Fix issue: spark session created on spark executor

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -562,7 +562,7 @@ _FILE_AVAILABILITY_WAIT_TIMEOUT_SECS = 30
 
 def _wait_file_available(url_list):
     """
-    Waiting about SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF seconds to make sure
+    Waiting about _FILE_AVAILABILITY_WAIT_TIMEOUT_SECS seconds (default 30 seconds) to make sure
     all files are available for reading. This is useful in some filesystems, such as S3 which only
     providing eventually consistency.
     """

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 
 def _get_spark_session():
+    """
+    Get or create spark session.
+    Note: This function can only be invoked from driver side.
+    """
     return SparkSession.builder.getOrCreate()
 
 
@@ -172,7 +176,6 @@ class SparkDatasetConverter(object):
     """
 
     PARENT_CACHE_DIR_URL_CONF = 'petastorm.spark.converter.parentCacheDirUrl'
-    FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF = 'petastorm.spark.converter.fileAvailabilityWaitTimeoutSecs'
 
     def __init__(self, cache_dir_url, file_urls, dataset_size):
         """
@@ -551,6 +554,9 @@ def _materialize_df(df, parent_cache_dir_url, parquet_row_group_size_bytes,
     return save_to_dir_url
 
 
+_FILE_AVAILABILITY_WAIT_TIMEOUT_SECS = 30
+
+
 def _wait_file_available(url_list):
     """
     Waiting about SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF seconds to make sure
@@ -558,15 +564,10 @@ def _wait_file_available(url_list):
     providing eventually consistency.
     """
     fs, path_list = get_filesystem_and_path_or_paths(url_list)
-    wait_seconds = _get_spark_session().conf \
-        .get(SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF, '30')
-    wait_seconds = int(wait_seconds)
-    if wait_seconds <= 0:
-        return
     logger.debug('Waiting some seconds until all parquet-store files appear at urls %s', ','.join(url_list))
 
     def wait_for_file(path):
-        end_time = time.time() + wait_seconds
+        end_time = time.time() + _FILE_AVAILABILITY_WAIT_TIMEOUT_SECS
         while time.time() < end_time:
             if fs.exists(path):
                 return True

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -49,6 +49,9 @@ def _get_spark_session():
     Get or create spark session.
     Note: This function can only be invoked from driver side.
     """
+    if pyspark.TaskContext.get() is not None:
+        # This is a safety check.
+        raise RuntimeError('_get_spark_session should not be invoked from executor side.')
     return SparkSession.builder.getOrCreate()
 
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -56,9 +56,11 @@ class TestContext(object):
         self.tempdir = tempfile.mkdtemp('_spark_converter_test')
         self.temp_url = 'file://' + self.tempdir.replace(os.sep, '/')
         self.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, self.temp_url)
-        self.spark.conf.set(SparkDatasetConverter.FILE_AVAILABILITY_WAIT_TIMEOUT_SECS_CONF, '2')
+        spark_dataset_converter._FILE_AVAILABILITY_WAIT_TIMEOUT_SECS = 2
 
     def tear_down(self):
+        # restore default file availability wait timeout
+        spark_dataset_converter._FILE_AVAILABILITY_WAIT_TIMEOUT_SECS = 30
         self.spark.stop()
 
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -23,6 +23,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import pyspark
 import pytest
+import py4j
 import tensorflow as tf
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import pandas_udf
@@ -38,8 +39,8 @@ from petastorm.spark import (SparkDatasetConverter, make_spark_converter,
 from petastorm.spark.spark_dataset_converter import (
     _check_dataset_file_median_size, _check_parent_cache_dir_url,
     _check_rank_and_size_consistent_with_horovod, _check_url,
-    _get_horovod_rank_and_size, _make_sub_dir_url,
-    _wait_file_available, register_delete_dir_handler)
+    _get_horovod_rank_and_size, _get_spark_session, _make_sub_dir_url,
+    register_delete_dir_handler, _wait_file_available)
 
 try:
     from mock import mock
@@ -599,3 +600,12 @@ def test_check_parent_cache_dir_url(test_ctx, caplog):
         caplog.clear()
         _check_parent_cache_dir_url('file:/a/b')
         assert not log_warning_occur()
+
+
+def test_get_spark_session_safe_check(test_ctx):
+    def map_fn(_):
+        _get_spark_session()
+        return 0
+
+    with pytest.raises(py4j.protocol.Py4JJavaError):
+        test_ctx.spark.sparkContext.parallelize(range(1), 1).map(map_fn).collect()


### PR DESCRIPTION
Current code exists an issue that spark session will be created on spark executor.
This is because `_get_spark_session` being invoked by `_wait_file_available`, and `_wait_file_available` will be invoked from executor side.

So I fix it. I removed the config `petastorm.spark.converter.fileAvailabilityWaitTimeoutSecs`, the config is rarely used.