### PR TITLE
[ML-10366]  Fix bug: cleanup metadata in converter.delete()

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -109,8 +109,8 @@ def register_delete_dir_handler(handler):
 def _delete_cache_data_atexit(dataset_url):
     try:
         _delete_dir_handler(dataset_url)
-    except Exception:  # pylint: disable=broad-except
-        logger.warning('delete cache data %s failed.', dataset_url)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning('Delete cache data %s failed due to %s', dataset_url, repr(e))
 
 
 def _get_horovod_rank_and_size():
@@ -274,7 +274,7 @@ class SparkDatasetConverter(object):
         """
         Delete cache files at self.cache_dir_url.
         """
-        _remove_df_from_cache(self.cache_dir_url)
+        _remove_cache_metadata_and_data(self.cache_dir_url)
 
 
 class TFDatasetContextManager(object):
@@ -475,7 +475,7 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
         return cached_df_meta.cache_dir_url
 
 
-def _remove_df_from_cache(cache_dir_url):
+def _remove_cache_metadata_and_data(cache_dir_url):
     with _cache_df_meta_list_lock:
         for i in range(len(_cache_df_meta_list)):
             if _cache_df_meta_list[i].cache_dir_url == cache_dir_url:

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -234,6 +234,20 @@ def test_df_caching(test_ctx):
     assert converter12.cache_dir_url != converter22.cache_dir_url
 
 
+def test_df_delete_caching_meta(test_ctx):
+    from petastorm.spark.spark_dataset_converter import _cache_df_meta_list
+    df1 = test_ctx.spark.range(10)
+    df2 = test_ctx.spark.range(20)
+    converter1 = make_spark_converter(df1)
+    converter2 = make_spark_converter(df2)
+    converter1.delete()
+    cached_list = list(map(lambda x: x.cache_dir_url, _cache_df_meta_list))
+    assert converter1.cache_dir_url not in cached_list
+    assert converter2.cache_dir_url in cached_list
+    # test recreate converter1 after delete should work.
+    make_spark_converter(df1)
+
+
 def test_check_url():
     with pytest.raises(ValueError, match='scheme-less'):
         _check_url('/a/b/c')

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -241,7 +241,7 @@ def test_df_delete_caching_meta(test_ctx):
     converter1 = make_spark_converter(df1)
     converter2 = make_spark_converter(df2)
     converter1.delete()
-    cached_list = list(map(lambda x: x.cache_dir_url, _cache_df_meta_list))
+    cached_list = set(map(lambda x: x.cache_dir_url, _cache_df_meta_list))
     assert converter1.cache_dir_url not in cached_list
     assert converter2.cache_dir_url in cached_list
     # test recreate converter1 after delete should work.


### PR DESCRIPTION
When the user wants to manually delete the cache files and create a new cache, they do:

~~~python
converter.delete()
converter = make_spark_converter(df)
~~~
Get error:
```
org.apache.spark.sql.AnalysisException: Path does not exist: file:/dbfs/ml/tmp/petastorm/QA/keras/20200407043623-appid-app-20200406162107-0000-d7d7cdfd-3739-48d0-9dc1-bffba08fff12;
```

Fix: We should cleanup cache metadata in SparkDatasetConverter.delete() besides deleting the data files.