### PR TITLE
handle names like [path]/part/

### DIFF
--- a/petastorm/gcsfs_helpers/gcsfs_wrapper.py
+++ b/petastorm/gcsfs_helpers/gcsfs_wrapper.py
@@ -46,7 +46,7 @@ class GCSFSWrapper(DaskFileSystem):
             # we check also for names like [path]/part/
             path = key['name']
             if key['storageClass'] == 'DIRECTORY':
-                if path..endswith('/'):
+                if path.endswith('/'):
                     directories.add(path[:-1])
                 else:
                     directories.add(path)

--- a/petastorm/gcsfs_helpers/gcsfs_wrapper.py
+++ b/petastorm/gcsfs_helpers/gcsfs_wrapper.py
@@ -46,7 +46,10 @@ class GCSFSWrapper(DaskFileSystem):
             # we check also for names like [path]/part/
             path = key['name']
             if key['storageClass'] == 'DIRECTORY':
-                directories.add(path)
+                if path..endswith('/'):
+                    directories.add(path[:-1])
+                else:
+                    directories.add(path)
             elif key['storageClass'] == 'BUCKET':
                 pass
             else:


### PR DESCRIPTION
gcsfs returns name as [path]/part/, and in this case. Following code will set directories to list of empty strings.
```
        directories = sorted([posixpath.split(x)[1]
                              for x in directories])
```