### PR TITLE
Fix bug: respect dynamically changed parent cache dir conf

### DIFF
--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 
 import pyarrow
 import six
@@ -18,6 +19,8 @@ from six.moves.urllib.parse import urlparse
 
 from petastorm.gcsfs_helpers.gcsfs_wrapper import GCSFSWrapper
 from petastorm.hdfs.namenode import HdfsNamenodeResolver, HdfsConnector
+
+logger = logging.getLogger(__name__)
 
 
 def get_dataset_path(parsed_url):
@@ -223,3 +226,12 @@ def get_filesystem_and_path_or_paths(url_or_urls, hdfs_driver='libhdfs3'):
         path_or_paths = path_list[0]
 
     return fs, path_or_paths
+
+
+def normalize_dir_url(dataset_url):
+    if dataset_url is None or not isinstance(dataset_url, six.string_types):
+        raise ValueError('directory url must be a string')
+
+    dataset_url = dataset_url[:-1] if dataset_url[-1] == '/' else dataset_url
+    logger.debug('directory url: %s', dataset_url)
+    return dataset_url

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -24,7 +24,7 @@ from petastorm.cache import NullCache
 from petastorm.errors import NoDataAvailableError
 from petastorm.etl import dataset_metadata, rowgroup_indexing
 from petastorm.etl.dataset_metadata import PetastormMetadataError, infer_or_load_unischema
-from petastorm.fs_utils import get_filesystem_and_path_or_paths
+from petastorm.fs_utils import get_filesystem_and_path_or_paths, normalize_dir_url
 from petastorm.local_disk_arrow_table_cache import LocalDiskArrowTableCache
 from petastorm.local_disk_cache import LocalDiskCache
 from petastorm.ngram import NGram
@@ -47,22 +47,13 @@ logger = logging.getLogger(__name__)
 _VENTILATE_EXTRA_ROWGROUPS = 2
 
 
-def normalize_dataset_url(dataset_url):
-    if dataset_url is None or not isinstance(dataset_url, six.string_types):
-        raise ValueError('dataset url must be a string')
-
-    dataset_url = dataset_url[:-1] if dataset_url[-1] == '/' else dataset_url
-    logger.debug('dataset url: %s', dataset_url)
-    return dataset_url
-
-
 def normalize_dataset_url_or_urls(dataset_url_or_urls):
     if isinstance(dataset_url_or_urls, list):
         if not dataset_url_or_urls:
             raise ValueError('dataset url list must be non-empty.')
-        return [normalize_dataset_url(url) for url in dataset_url_or_urls]
+        return [normalize_dir_url(url) for url in dataset_url_or_urls]
     else:
-        return normalize_dataset_url(dataset_url_or_urls)
+        return normalize_dir_url(dataset_url_or_urls)
 
 
 def make_reader(dataset_url,
@@ -128,7 +119,7 @@ def make_reader(dataset_url,
         on the ``reader_pool_type`` value).
     :return: A :class:`Reader` object
     """
-    dataset_url = normalize_dataset_url(dataset_url)
+    dataset_url = normalize_dir_url(dataset_url)
 
     filesystem, dataset_path = get_filesystem_and_path_or_paths(dataset_url, hdfs_driver)
 

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -384,7 +384,7 @@ def _get_df_plan(df):
 
 class CachedDataFrameMeta(object):
 
-    def __init__(self, df, row_group_size, compression_codec, dtype):
+    def __init__(self, df, parent_cache_dir_url, row_group_size, compression_codec, dtype):
         self.row_group_size = row_group_size
         self.compression_codec = compression_codec
         # Note: the metadata will hold dataframe plan, but it won't
@@ -394,11 +394,12 @@ class CachedDataFrameMeta(object):
         self.df_plan = _get_df_plan(df)
         self.cache_dir_url = None
         self.dtype = dtype
+        self.parent_cache_dir_url = parent_cache_dir_url
 
     @classmethod
     def create_cached_dataframe(cls, df, parent_cache_dir_url, row_group_size,
                                 compression_codec, dtype):
-        meta = cls(df, row_group_size, compression_codec, dtype)
+        meta = cls(df, parent_cache_dir_url, row_group_size, compression_codec, dtype)
         meta.cache_dir_url = _materialize_df(
             df,
             parent_cache_dir_url=parent_cache_dir_url,
@@ -478,7 +479,8 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
             if meta.row_group_size == parquet_row_group_size_bytes and \
                     meta.compression_codec == compression_codec and \
                     meta.df_plan.sameResult(df_plan) and \
-                    meta.dtype == dtype:
+                    meta.dtype == dtype and \
+                    meta.parent_cache_dir_url == parent_cache_dir_url:
                 return meta.cache_dir_url
         # do not find cached dataframe, start materializing.
         cached_df_meta = CachedDataFrameMeta.create_cached_dataframe(

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -31,8 +31,7 @@ from six.moves.urllib.parse import urlparse
 
 from petastorm import make_batch_reader
 from petastorm.fs_utils import (FilesystemResolver,
-                                get_filesystem_and_path_or_paths)
-from petastorm.reader import normalize_dataset_url
+                                get_filesystem_and_path_or_paths, normalize_dir_url)
 
 if LooseVersion(pyspark.__version__) < LooseVersion('3.0'):
     def vector_to_array(_1, _2='float32'):
@@ -73,7 +72,7 @@ def _get_parent_cache_dir_url():
         raise ValueError(
             "Please set the spark config {}.".format(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
 
-    conf_url = normalize_dataset_url(conf_url)
+    conf_url = normalize_dir_url(conf_url)
     _check_parent_cache_dir_url(conf_url)
     _parent_cache_dir_url = conf_url
     logger.info(

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -32,6 +32,7 @@ from six.moves.urllib.parse import urlparse
 from petastorm import make_batch_reader
 from petastorm.fs_utils import (FilesystemResolver,
                                 get_filesystem_and_path_or_paths)
+from petastorm.reader import normalize_dataset_url
 
 if LooseVersion(pyspark.__version__) < LooseVersion('3.0'):
     def vector_to_array(_1, _2='float32'):
@@ -70,12 +71,13 @@ def _get_parent_cache_dir_url():
 
     if conf_url is None:
         raise ValueError(
-            "Please set the spark config petastorm.spark.converter.parentCacheDirUrl.")
+            "Please set the spark config {}.".format(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF))
 
+    conf_url = normalize_dataset_url(conf_url)
     _check_parent_cache_dir_url(conf_url)
     _parent_cache_dir_url = conf_url
     logger.info(
-        'Read petastorm.spark.converter.parentCacheDirUrl %s', _parent_cache_dir_url)
+        'Read %s %s', SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, _parent_cache_dir_url)
 
     return _parent_cache_dir_url
 
@@ -390,8 +392,8 @@ class CachedDataFrameMeta(object):
         self.parent_cache_dir_url = parent_cache_dir_url
 
     @classmethod
-    def create_cached_dataframe(cls, df, parent_cache_dir_url, row_group_size,
-                                compression_codec, dtype):
+    def create_cached_dataframe_meta(cls, df, parent_cache_dir_url, row_group_size,
+                                     compression_codec, dtype):
         meta = cls(df, parent_cache_dir_url, row_group_size, compression_codec, dtype)
         meta.cache_dir_url = _materialize_df(
             df,

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -236,6 +236,17 @@ def test_df_caching(test_ctx):
     converter22 = make_spark_converter(df1, compression_codec="snappy")
     assert converter12.cache_dir_url != converter22.cache_dir_url
 
+    ori_temp_url = test_ctx.spark.conf.get(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF)
+    tempdir = tempfile.mkdtemp('_spark_converter_test1')
+    new_temp_url = 'file://' + tempdir.replace(os.sep, '/')
+    test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
+                            new_temp_url)
+    assert ori_temp_url != new_temp_url
+    converter13 = make_spark_converter(df1)
+    assert converter1.cache_dir_url != converter13.cache_dir_url
+    test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
+                            ori_temp_url)
+
 
 def test_check_url():
     with pytest.raises(ValueError, match='scheme-less'):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -219,19 +219,23 @@ def test_df_caching(test_ctx):
     df2 = test_ctx.spark.range(10)
     df3 = test_ctx.spark.range(20)
 
+    # Test caching for the dataframes with the same logical plan
     converter1 = make_spark_converter(df1)
     converter2 = make_spark_converter(df2)
     assert converter1.cache_dir_url == converter2.cache_dir_url
 
+    # Test no caching for different dataframes
     converter3 = make_spark_converter(df3)
     assert converter1.cache_dir_url != converter3.cache_dir_url
 
+    # Test no caching for the same dataframe with different row group size
     converter11 = make_spark_converter(
         df1, parquet_row_group_size_bytes=8 * 1024 * 1024)
     converter21 = make_spark_converter(
         df1, parquet_row_group_size_bytes=16 * 1024 * 1024)
     assert converter11.cache_dir_url != converter21.cache_dir_url
 
+    # Test no caching for the same dataframe with different compression_codec
     converter12 = make_spark_converter(df1, compression_codec=None)
     converter22 = make_spark_converter(df1, compression_codec="snappy")
     assert converter12.cache_dir_url != converter22.cache_dir_url
@@ -239,13 +243,25 @@ def test_df_caching(test_ctx):
     ori_temp_url = test_ctx.spark.conf.get(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF)
     tempdir = tempfile.mkdtemp('_spark_converter_test1')
     new_temp_url = 'file://' + tempdir.replace(os.sep, '/')
-    test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
-                            new_temp_url)
-    assert ori_temp_url != new_temp_url
-    converter13 = make_spark_converter(df1)
-    assert converter1.cache_dir_url != converter13.cache_dir_url
-    test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
-                            ori_temp_url)
+    try:
+        # Test no caching for the same dataframe with different parent cache dirs
+        test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
+                                new_temp_url)
+        assert ori_temp_url != new_temp_url
+        converter13 = make_spark_converter(df1)
+        assert converter1.cache_dir_url != converter13.cache_dir_url
+
+        # Test caching for the same dataframe with different parent cache dirs
+        # that could be normalized to the same parent cache dir
+        new_temp_url_2 = new_temp_url + os.sep
+        test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
+                                new_temp_url_2)
+        assert new_temp_url != new_temp_url_2
+        converter14 = make_spark_converter(df1)
+        assert converter13.cache_dir_url == converter14.cache_dir_url
+    finally:
+        test_ctx.spark.conf.set(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF,
+                                ori_temp_url)
 
 
 def test_df_delete_caching_meta(test_ctx):


### PR DESCRIPTION
Bug: If we execute the following code:
```python
spark.conf.set("petastorm.spark.converter.parentCacheDirUrl", "file:///url1")
converter1 = make_spark_converter(df)   # This works fine.
# Change conf
spark.conf.set("petastorm.spark.converter.parentCacheDirUrl", "file:///url2")
converter2 = make_spark_converter(df)
```
The last line will hit cache:
```The median size (1333465) of these parquet files (file:/url1/file_abc.parquet) is too small.Increase file sizes by repartition or coalesce spark dataframe, which will help improve performance.```
indicating that the new conf parent dir is not respected (still hitting the .../url1 dir).

Fix: We respect the conf change by adding an equality test against the parent cache dir.