### PR TITLE
Fix: The "median size too small" warning is too frequent

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -607,8 +607,8 @@ def _check_dataset_file_median_size(url_list):
                 if median_size < SIZE_LIMIT_BYTES:
                     logger.warning('The median size %d MB (< 50 MB) of the parquet files is too small. '
                                    'Total size: %d MB. Increase the median file size by calling df.repartition(n) or '
-                                   'df.coalesce(n), which will help improve the performance.',
-                                   median_size // MB_BYTES, total_size // MB_BYTES)
+                                   'df.coalesce(n), which will help improve the performance. Parquet files: %s, ...',
+                                   median_size // MB_BYTES, total_size // MB_BYTES, url_list[0])
         finally:
             pool.close()
             pool.join()

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -592,18 +592,23 @@ def _wait_file_available(url_list):
 
 def _check_dataset_file_median_size(url_list):
     fs, path_list = get_filesystem_and_path_or_paths(url_list)
+    SIZE_LIMIT_BYTES = 50 * 1024 * 1024
+    MB_BYTES = 1024 * 1024
 
     # TODO: also check file size for other file system.
     if isinstance(fs, LocalFileSystem):
         pool = ThreadPool(64)
         try:
             file_size_list = pool.map(os.path.getsize, path_list)
-            mid_index = len(file_size_list) // 2
-            median_size = sorted(file_size_list)[mid_index]
-            if median_size < 50 * 1024 * 1024:
-                logger.warning('The median size (%d) of these parquet files (%s) is too small.'
-                               'Increase file sizes by repartition or coalesce spark dataframe, which '
-                               'will help improve performance.', median_size, ','.join(url_list))
+            total_size = sum(file_size_list)
+            if total_size > SIZE_LIMIT_BYTES:
+                mid_index = len(file_size_list) // 2
+                median_size = sorted(file_size_list)[mid_index]
+                if median_size < SIZE_LIMIT_BYTES:
+                    logger.warning('The median size %d MB (< 50 MB) of the parquet files is too small. '
+                                   'Total size: %d MB. Increase the median file size by calling df.repartition(n) or '
+                                   'df.coalesce(n), which will help improve the performance.',
+                                   median_size // MB_BYTES, total_size // MB_BYTES)
         finally:
             pool.close()
             pool.join()

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -562,10 +562,10 @@ def test_wait_file_available(test_ctx):
 
 def test_check_dataset_file_median_size(test_ctx, caplog):
     file_size_map = {
-        '/a/b/01.parquet': 50,
-        '/a/b/02.parquet': 70,
-        '/a/b/03.parquet': 60,
-        '/a/b/04.parquet': 65,
+        '/a/b/01.parquet': 29,
+        '/a/b/02.parquet': 39,
+        '/a/b/03.parquet': 49,
+        '/a/b/04.parquet': 59,
         '/a/b/05.parquet': 999000,
     }
     with mock.patch('os.path.getsize') as mock_path_get_size:
@@ -573,12 +573,18 @@ def test_check_dataset_file_median_size(test_ctx, caplog):
         url_list = ['file://' + path for path in file_size_map.keys()]
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size (65) of these parquet files' in '\n'.join([r.message for r in caplog.records])
+        assert len(caplog.records) == 0
+
         for k in file_size_map:
             file_size_map[k] *= (1024 * 1024)
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size (68157440) of these parquet files' not in '\n'.join([r.message for r in caplog.records])
+        assert 'The median size 49 MB (< 50 MB) of the parquet files' in caplog.messages[0]
+
+        file_size_map['/a/b/03.parquet'] = 51 * 1024 * 1024
+        caplog.clear()
+        _check_dataset_file_median_size(url_list)
+        assert len(caplog.records) == 0
 
 
 @mock.patch.dict(os.environ, {'DATABRICKS_RUNTIME_VERSION': '7.0'}, clear=True)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -576,10 +576,10 @@ def test_wait_file_available(test_ctx):
 
 def test_check_dataset_file_median_size(test_ctx, caplog):
     file_size_map = {
-        '/a/b/01.parquet': 29,
-        '/a/b/02.parquet': 39,
-        '/a/b/03.parquet': 49,
-        '/a/b/04.parquet': 59,
+        '/a/b/01.parquet': 30,
+        '/a/b/02.parquet': 40,
+        '/a/b/03.parquet': 50,
+        '/a/b/04.parquet': 60,
         '/a/b/05.parquet': 999000,
     }
     with mock.patch('os.path.getsize') as mock_path_get_size:
@@ -587,18 +587,19 @@ def test_check_dataset_file_median_size(test_ctx, caplog):
         url_list = ['file://' + path for path in file_size_map.keys()]
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size ' not in " ".join(caplog.messages)
+        assert 'The median size' in " ".join(caplog.messages)
 
         for k in file_size_map:
             file_size_map[k] *= (1024 * 1024)
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size 49 MB (< 50 MB) of the parquet files' in " ".join(caplog.messages)
+        assert 'The median size' not in " ".join(caplog.messages)
 
-        file_size_map['/a/b/03.parquet'] = 51 * 1024 * 1024
+        file_size_map = {'/a/b/01.parquet': 29}
+        url_list = ['file:///a/b/01.parquet']
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size ' not in " ".join(caplog.messages)
+        assert 'The median size' not in " ".join(caplog.messages)
 
 
 @mock.patch.dict(os.environ, {'DATABRICKS_RUNTIME_VERSION': '7.0'}, clear=True)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -573,18 +573,18 @@ def test_check_dataset_file_median_size(test_ctx, caplog):
         url_list = ['file://' + path for path in file_size_map.keys()]
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert len(caplog.records) == 0
+        assert 'The median size ' not in " ".join(caplog.messages)
 
         for k in file_size_map:
             file_size_map[k] *= (1024 * 1024)
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert 'The median size 49 MB (< 50 MB) of the parquet files' in caplog.messages[0]
+        assert 'The median size 49 MB (< 50 MB) of the parquet files' in " ".join(caplog.messages)
 
         file_size_map['/a/b/03.parquet'] = 51 * 1024 * 1024
         caplog.clear()
         _check_dataset_file_median_size(url_list)
-        assert len(caplog.records) == 0
+        assert 'The median size ' not in " ".join(caplog.messages)
 
 
 @mock.patch.dict(os.environ, {'DATABRICKS_RUNTIME_VERSION': '7.0'}, clear=True)


### PR DESCRIPTION
Problem: This warning below shows up even when there is only one partition, and the file list could be too long to read.
```
The median size (1333465) of these parquet files (file list...) is too small.Increase file sizes by repartition or coalesce spark dataframe, which will help improve performance.
```

Fix: 
1. Only print warning for (num_of_files > 1 && median file size < 50MB)
2. Remove the file list in the warning.
3. Provide the total size of the dataset and the threshold file size (50MB) in the warning to help users to decide how many partitions do they need.

Test:
Added unit test in `test_check_dataset_file_median_size`.