### PR TITLE
Import petastorm.spark in init

### DIFF
--- a/petastorm/__init__.py
+++ b/petastorm/__init__.py
@@ -17,8 +17,9 @@ import warnings
 from petastorm.errors import NoDataAvailableError  # noqa: F401
 from petastorm.reader import make_reader, make_batch_reader  # noqa: F401
 from petastorm.transform import TransformSpec  # noqa: F401
+import petastorm.spark
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 if sys.version_info.major < 3:
     warnings.warn('Petastorm on Python 2 is deprecated and will remove Python 2 support in next release.')


### PR DESCRIPTION
## Issue

1. I install petastorm `pip install petastorm`
2. Run `from petastorm.spark import X, Y, Z` and I get the error 
```python
ModuleNotFoundError : No module named 'petastorm.spark'
```
## Fix
- Added import petastorm.spark in init
- Updated the version so pip builds happen.

I'm **not sure if this is the right way**, since there are nuances about releases and how petastorm currently does python module management.