### PR TITLE
Added last_row_consumed property to WeightedSamplingReader

### DIFF
--- a/petastorm/weighted_sampling_reader.py
+++ b/petastorm/weighted_sampling_reader.py
@@ -94,6 +94,10 @@ class WeightedSamplingReader(object):
     def next(self):
         return self.__next__()
 
+    @property
+    def last_row_consumed(self):
+        return any(map(lambda r: r.last_row_consumed, self._readers))
+
     # Functions needed to treat reader as a context manager
     def __enter__(self):
         return self


### PR DESCRIPTION
Without this property, `make_petastorm_dataset` was crashing if `WeightedSamplingReader` reader was passed to it.