### PR TITLE
Remove driver param for hdfs.connect when using pyarrow 0.17 and above

### DIFF
--- a/petastorm/hdfs/namenode.py
+++ b/petastorm/hdfs/namenode.py
@@ -263,7 +263,13 @@ class HdfsConnector(object):
         else:
             hostname = six.text_type(url.hostname or 'default')
             driver = six.text_type(driver)
-        return pyarrow.hdfs.connect(hostname, url.port or 8020, driver=driver, user=user)
+
+        kwargs = dict(user=user)
+        if LooseVersion(pyarrow.__version__) < LooseVersion('0.17.0'):
+            # Support for libhdfs3 was removed in v0.17.0, we include it here for backwards
+            # compatibility
+            kwargs['driver'] = driver
+        return pyarrow.hdfs.connect(hostname, url.port or 8020, **kwargs)
 
     @classmethod
     def connect_to_either_namenode(cls, list_of_namenodes, user=None):


### PR DESCRIPTION
See: https://github.com/apache/arrow/pull/6432

Related Horovod issue: https://github.com/horovod/horovod/issues/2000