### PR TITLE
Use mypy in our CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ before_script:
 
   - $RUN pip list
 
+  - $RUN mypy petastorm
+
   # We run a bunch of linting in before_script to fail fast and not run unit tests in case of lint failure.
   - $RUN flake8 . --count --show-source --statistics
   - $RUN flake8 . --count --exit-zero --max-complexity=10 --statistics

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = True
+
+[mypy-petatstorm.unischema.*]
+ignore_errors = True

--- a/petastorm/hdfs/tests/test_hdfs_namenode.py
+++ b/petastorm/hdfs/tests/test_hdfs_namenode.py
@@ -16,14 +16,12 @@ import os
 import pickle
 import textwrap
 import unittest
+from typing import Dict
 
 import pytest
 from pyarrow.lib import ArrowIOError
 
-try:
-    from unittest import mock
-except ImportError:
-    from mock import mock
+from unittest import mock
 
 from petastorm.hdfs.namenode import HdfsNamenodeResolver, HdfsConnector, \
     HdfsConnectError, MaxFailoversExceeded, HAHdfsClient, namenode_failover
@@ -295,7 +293,7 @@ class MockHdfsConnector(HdfsConnector):
     # static member for static hdfs_connect_namenode to access
     _n_failovers = 0
     _fail_n_next_connect = 0
-    _connect_attempted = {}
+    _connect_attempted: Dict[str, int] = {}
 
     @classmethod
     def reset(cls):

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -26,7 +26,7 @@ from packaging import version
 from petastorm.reader_impl.shuffling_buffer import RandomShufflingBuffer, NoopShufflingBuffer
 from petastorm.reader_impl.pytorch_shuffling_buffer import BatchedRandomShufflingBuffer, BatchedNoopShufflingBuffer
 
-_TORCH_BEFORE_1_1 = version.parse(torch.__version__) < version.parse('1.1.0')
+_TORCH_BEFORE_1_1 = version.parse(torch.__version__) < version.parse('1.1.0')  # type: ignore
 
 if PY2:
     _string_classes = basestring  # noqa: F821

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -22,6 +22,7 @@ import time
 import uuid
 from distutils.version import LooseVersion
 from multiprocessing.pool import ThreadPool
+from typing import List, Any
 
 import pyspark
 from pyarrow import LocalFileSystem
@@ -37,7 +38,7 @@ if LooseVersion(pyspark.__version__) < LooseVersion('3.0'):
     def vector_to_array(_1, _2='float32'):
         raise RuntimeError("Vector columns are only supported in pyspark>=3.0")
 else:
-    from pyspark.ml.functions import vector_to_array  # pylint: disable=import-error
+    from pyspark.ml.functions import vector_to_array  # type: ignore  # pylint: disable=import-error
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
 
@@ -398,7 +399,7 @@ class CachedDataFrameMeta(object):
         return meta
 
 
-_cache_df_meta_list = []
+_cache_df_meta_list: List[Any] = []  # TODO(Yevgeni): can be more precise with the type (instead of Any)
 _cache_df_meta_list_lock = threading.Lock()
 
 

--- a/petastorm/tests/test_benchmark.py
+++ b/petastorm/tests/test_benchmark.py
@@ -15,10 +15,7 @@ from time import sleep
 
 import six
 
-try:
-    from unittest import mock
-except ImportError:
-    from mock import mock
+from unittest import mock
 
 from petastorm.benchmark.throughput import reader_throughput, _time_warmup_and_work, WorkerPoolType, ReadMethod
 

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -23,10 +23,7 @@ import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import LongType, ShortType, StringType
 
-try:
-    from mock import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from petastorm import make_reader, make_batch_reader, TransformSpec
 from petastorm.codecs import ScalarCodec, CompressedImageCodec

--- a/petastorm/tests/test_ngram_end_to_end.py
+++ b/petastorm/tests/test_ngram_end_to_end.py
@@ -21,10 +21,7 @@ import numpy as np
 import pytest
 import tensorflow.compat.v1 as tf  # pylint: disable=import-error
 
-try:
-    from mock import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from petastorm import make_reader
 from petastorm.ngram import NGram

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -41,10 +41,7 @@ from petastorm.spark.spark_dataset_converter import (
     _get_horovod_rank_and_size, _get_spark_session, _make_sub_dir_url,
     register_delete_dir_handler, _wait_file_available)
 
-try:
-    from mock import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from petastorm.tests.test_tf_utils import create_tf_graph
 
@@ -309,7 +306,7 @@ def test_tf_dataset_petastorm_args(mock_make_batch_reader, spark_test_ctx):
 
     with conv1.make_tf_dataset(reader_pool_type='dummy', cur_shard=1, shard_count=4):
         pass
-    peta_args = mock_make_batch_reader.call_args.kwargs
+    peta_args = mock_make_batch_reader.call_args[1]
     assert peta_args['reader_pool_type'] == 'dummy' and \
         peta_args['cur_shard'] == 1 and \
         peta_args['shard_count'] == 4 and \
@@ -318,7 +315,7 @@ def test_tf_dataset_petastorm_args(mock_make_batch_reader, spark_test_ctx):
 
     with conv1.make_tf_dataset(num_epochs=1, workers_count=2):
         pass
-    peta_args = mock_make_batch_reader.call_args.kwargs
+    peta_args = mock_make_batch_reader.call_args[1]
     assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
 
 
@@ -536,7 +533,7 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, spark_te
     with conv.make_torch_dataloader(reader_pool_type='dummy', cur_shard=1,
                                     shard_count=SHARD_COUNT) as _:
         pass
-    peta_args = mock_torch_make_batch_reader.call_args.kwargs
+    peta_args = mock_torch_make_batch_reader.call_args[1]
     assert peta_args['reader_pool_type'] == 'dummy' and \
         peta_args['cur_shard'] == 1 and \
         peta_args['shard_count'] == SHARD_COUNT and \
@@ -546,7 +543,7 @@ def test_torch_dataloader_advanced_params(mock_torch_make_batch_reader, spark_te
     # Test default value overridden arguments.
     with conv.make_torch_dataloader(num_epochs=1, workers_count=2) as _:
         pass
-    peta_args = mock_torch_make_batch_reader.call_args.kwargs
+    peta_args = mock_torch_make_batch_reader.call_args[1]
     assert peta_args['num_epochs'] == 1 and peta_args['workers_count'] == 2
 
 

--- a/petastorm/tests/test_tf_utils.py
+++ b/petastorm/tests/test_tf_utils.py
@@ -26,10 +26,7 @@ from packaging import version
 import pytest
 import tensorflow.compat.v1 as tf  # pylint: disable=import-error
 
-try:
-    from mock import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from petastorm import make_reader, make_batch_reader, TransformSpec
 from petastorm.ngram import NGram

--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -27,10 +27,7 @@ from petastorm.codecs import ScalarCodec, NdarrayCodec
 from petastorm.unischema import Unischema, UnischemaField, dict_to_spark_row, \
     insert_explicit_nulls, match_unischema_fields, _new_gt_255_compatible_namedtuple, _fullmatch
 
-try:
-    from unittest import mock
-except ImportError:
-    from mock import mock
+from unittest import mock
 
 
 def _mock_parquet_dataset(partitions, arrow_schema):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ REQUIRED_PACKAGES = [
     'dill>=0.2.1',
     'diskcache>=3.0.0',
     'future>=0.10.2',
+    'gcsfs>=0.2.0',
     'numpy>=1.13.3',
     'packaging>=15.0',
     'pandas>=0.19.0',
@@ -55,11 +56,12 @@ EXTRA_REQUIRE = {
     'tf': ['tensorflow>=1.14.0'],
     'tf_gpu': ['tensorflow-gpu>=1.14.0'],
     'test': [
-        'Pillow>=3.0',
+        'Pillow>=6.2.1',
         'codecov>=2.0.15',
-        'mock>=2.0.0',
-        'opencv-python>=3.2.0.6',
         'flake8',
+        'mock>=2.0.0',
+        'mypy',
+        'opencv-python>=3.2.0.6',
         'pylint>=1.9',
         'pytest>=3.0.0',
         'pytest-cov>=2.5.1',
@@ -68,9 +70,8 @@ EXTRA_REQUIRE = {
         'pytest-timeout>=1.3.3',
         'requests>=2.22.0',
         's3fs>=0.0.1',
-        'gcsfs>=0.2.0',
     ],
-    'torch': ['torchvision>=0.2.1'],
+    'torch': ['torchvision>=0.2.1', 'torch>=1.5.0'],
 }
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
Using mypy to run static type checking as part of travis build

Fixed some issues causing mypy to fail:
- Upgraded minimal torch and Pillow versions in `setup.py`
- Upgraded torch and Pillow in `.travis.yml`. This is a quick fix. A proper better way is to upgrade docker image used for the build.
- Rely on `unittest`'s `mock`
- Adding some type hints required by mypy