### PR TITLE
Ignore an invalid piece created for a subdirectory when a dataset is stored in an s3 bucket subdirectory

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,7 @@ Release notes
 
 Release 0.9.6 (unreleased)
 ==========================
+- `PR 588 <https://github.com/uber/petastorm/pull/588>`_: ``make_reader`` can now open a parquet dataset from a subdirectory in an s3 bucket.
 
 
 Release 0.9.5

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -281,9 +281,13 @@ def load_row_groups(dataset):
         # If we are not using absolute paths, we need to convert the path to a relative path for
         # looking up the number of row groups.
         row_groups_key = os.path.relpath(piece.path, dataset.paths)
-        for row_group in range(row_groups_per_file[row_groups_key]):
-            rowgroups.append(compat_make_parquet_piece(piece.path, dataset.fs.open, row_group=row_group,
-                                                       partition_keys=piece.partition_keys))
+
+        # When reading parquet store directly from an s3 bucket, a separate piece is created for root directory.
+        # This is not a real "piece" and we won't have row_groups_per_file recorded for it.
+        if row_groups_key != ".":
+            for row_group in range(row_groups_per_file[row_groups_key]):
+                rowgroups.append(compat_make_parquet_piece(piece.path, dataset.fs.open, row_group=row_group,
+                                                           partition_keys=piece.partition_keys))
     return rowgroups
 
 


### PR DESCRIPTION
When reading parquet store directly from an s3 bucket, a separate piece is created for root directory.
This is not a real "piece" and we won't have row_groups_per_file recorded for it.