### PR TITLE
Add a flag to factory methods to allow zmq copy buffers to be disabled

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,7 @@ Release notes
 Release 0.9.6 (unreleased)
 ==========================
 - `PR 588 <https://github.com/uber/petastorm/pull/588>`_: ``make_reader`` can now open a parquet dataset from a subdirectory in an s3 bucket.
+- `PR 596 <https://github.com/uber/petastorm/pull/596>`_: Add a flag to factory methods to allow zmq copy buffers to be disabled
 
 
 Release 0.9.5

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -68,7 +68,8 @@ def make_reader(dataset_url,
                 cache_row_size_estimate=None, cache_extra_settings=None,
                 hdfs_driver='libhdfs3',
                 transform_spec=None,
-                filters=None):
+                filters=None,
+                zmq_copy_buffers=True):
     """
     Creates an instance of Reader for reading Petastorm datasets. A Petastorm dataset is a dataset generated using
     :func:`~petastorm.etl.dataset_metadata.materialize_dataset` context manager as explained
@@ -121,6 +122,7 @@ def make_reader(dataset_url,
     :param filters: (List[Tuple] or List[List[Tuple]]): Standard PyArrow filters.
         These will be applied when loading the parquet file with PyArrow. More information
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
+    :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
     :return: A :class:`Reader` object
     """
     dataset_url = normalize_dir_url(dataset_url)
@@ -147,7 +149,7 @@ def make_reader(dataset_url,
             serializer = PyArrowSerializer()
         else:
             serializer = PickleSerializer()
-        reader_pool = ProcessPool(workers_count, serializer)
+        reader_pool = ProcessPool(workers_count, serializer, zmq_copy_buffers=zmq_copy_buffers)
     elif reader_pool_type == 'dummy':
         reader_pool = DummyPool()
     else:
@@ -193,7 +195,8 @@ def make_batch_reader(dataset_url_or_urls,
                       cache_row_size_estimate=None, cache_extra_settings=None,
                       hdfs_driver='libhdfs3',
                       transform_spec=None,
-                      filters=None):
+                      filters=None,
+                      zmq_copy_buffers=True):
     """
     Creates an instance of Reader for reading batches out of a non-Petastorm Parquet store.
 
@@ -250,6 +253,7 @@ def make_batch_reader(dataset_url_or_urls,
     :param filters: (List[Tuple] or List[List[Tuple]]): Standard PyArrow filters.
         These will be applied when loading the parquet file with PyArrow. More information
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
+    :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
     :return: A :class:`Reader` object
     """
     dataset_url_or_urls = normalize_dataset_url_or_urls(dataset_url_or_urls)
@@ -277,7 +281,7 @@ def make_batch_reader(dataset_url_or_urls,
         reader_pool = ThreadPool(workers_count)
     elif reader_pool_type == 'process':
         serializer = ArrowTableSerializer()
-        reader_pool = ProcessPool(workers_count, serializer)
+        reader_pool = ProcessPool(workers_count, serializer, zmq_copy_buffers=zmq_copy_buffers)
     elif reader_pool_type == 'dummy':
         reader_pool = DummyPool()
     else:

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -72,8 +72,9 @@ def test_bound_size_of_output_queue_size_reader(synthetic_dataset):
 def test_disable_zmq_copy_buffers_in_reader(synthetic_dataset):
     """Assert that the underlying ProcessPool has zmq_copy_buffers disabled"""
 
-    with make_reader(synthetic_dataset.url, reader_pool_type='process', workers_count=1, zmq_copy_buffers=False) as reader:
-        assert reader.diagnostics['zmq_copy_buffers'] == False
+    with make_reader(synthetic_dataset.url, reader_pool_type='process',
+                     workers_count=1, zmq_copy_buffers=False) as reader:
+        assert not reader.diagnostics['zmq_copy_buffers']
 
 
 @pytest.mark.parametrize('reader_factory', READER_FACTORIES)

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -69,6 +69,13 @@ def test_bound_size_of_output_queue_size_reader(synthetic_dataset):
         assert reader.diagnostics['items_inprocess'] < 5
 
 
+def test_disable_zmq_copy_buffers_in_reader(synthetic_dataset):
+    """Assert that the underlying ProcessPool has zmq_copy_buffers disabled"""
+
+    with make_reader(synthetic_dataset.url, reader_pool_type='process', workers_count=1, zmq_copy_buffers=False) as reader:
+        assert reader.diagnostics['zmq_copy_buffers'] == False
+
+
 @pytest.mark.parametrize('reader_factory', READER_FACTORIES)
 def test_invalid_cache_type(synthetic_dataset, reader_factory):
     with pytest.raises(ValueError, match='Unknown cache_type'):

--- a/petastorm/workers_pool/process_pool.py
+++ b/petastorm/workers_pool/process_pool.py
@@ -311,6 +311,7 @@ class ProcessPool(object):
             'items_consumed': self._ventilated_items,
             'items_produced': self._ventilated_items_processed,
             'items_inprocess': self._ventilated_items - self._ventilated_items_processed,
+            'zmq_copy_buffers': self._zmq_copy_buffers
         }
 
 


### PR DESCRIPTION
Addresses #595 