### PR TITLE
Use path with bucket name if it's an s3 path and a custom filesystem.

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,7 @@ Release 0.9.6 (unreleased)
 - `PR 588 <https://github.com/uber/petastorm/pull/588>`_: ``make_reader`` can now open a parquet dataset from a subdirectory in an s3 bucket.
 - `PR 594 <https://github.com/uber/petastorm/pull/594>`_: Parameterize factory methods with s3 configs
 - `PR 596 <https://github.com/uber/petastorm/pull/596>`_: Add a flag to factory methods to allow zmq copy buffers to be disabled
+- `PR 598 <https://github.com/uber/petastorm/pull/598>`_: Use path with bucket name if it's an s3 path and a custom filesystem.
 
 Release 0.9.5
 ==========================

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -26,7 +26,7 @@ from six.moves.urllib.parse import urlparse
 from petastorm import utils
 from petastorm.compat import compat_get_metadata, compat_make_parquet_piece
 from petastorm.etl.legacy import depickle_legacy_package_name_compatible
-from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths
+from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths, get_dataset_path
 from petastorm.unischema import Unischema
 from packaging import version
 
@@ -102,7 +102,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_
         filesystem_factory = resolver.filesystem_factory()
         dataset_path = resolver.get_dataset_path()
     else:
-        dataset_path = urlparse(dataset_url).path
+        dataset_path = get_dataset_path(urlparse(dataset_url))
     filesystem = filesystem_factory()
 
     dataset = pq.ParquetDataset(


### PR DESCRIPTION
When using s3 compatible object storage, we would like to pass in a S3FileSystem overriding the endpoint. The path should include the bucket name when it's s3 object storage.