### PR TITLE
Allow users to use s3, s3a and s3n protocols when saving / reading datasets

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,7 @@ Release 0.9.6 (unreleased)
 - `PR 588 <https://github.com/uber/petastorm/pull/588>`_: ``make_reader`` can now open a parquet dataset from a subdirectory in an s3 bucket.
 - `PR 594 <https://github.com/uber/petastorm/pull/594>`_: Parameterize factory methods with s3 configs
 - `PR 596 <https://github.com/uber/petastorm/pull/596>`_: Add a flag to factory methods to allow zmq copy buffers to be disabled
+- `PR 601 <https://github.com/uber/petastorm/pull/601>`_: Allow user to use s3, s3a and s3n url schemes when writing datasets.
 
 Release 0.9.5
 ==========================

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -18,17 +18,17 @@ import os
 from concurrent import futures
 from contextlib import contextmanager
 from operator import attrgetter
+from urllib.parse import urlparse
 
+from packaging import version
 from pyarrow import parquet as pq
 from six.moves import cPickle as pickle
-from six.moves.urllib.parse import urlparse
 
 from petastorm import utils
 from petastorm.compat import compat_get_metadata, compat_make_parquet_piece
 from petastorm.etl.legacy import depickle_legacy_package_name_compatible
-from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths
+from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths, get_dataset_path
 from petastorm.unischema import Unischema
-from packaging import version
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def materialize_dataset(spark, dataset_url, schema, row_group_size_mb=None, use_
         filesystem_factory = resolver.filesystem_factory()
         dataset_path = resolver.get_dataset_path()
     else:
-        dataset_path = urlparse(dataset_url).path
+        dataset_path = get_dataset_path(urlparse(dataset_url))
     filesystem = filesystem_factory()
 
     dataset = pq.ParquetDataset(

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -29,7 +29,7 @@ def get_dataset_path(parsed_url):
     For example s3fs expects the bucket name to be included in the path and doesn't support
     paths that start with a `/`
     """
-    if parsed_url.scheme.lower() in ['s3', 'gs', 'gcs']:
+    if parsed_url.scheme.lower() in ['s3', 's3a', 's3n', 'gs', 'gcs']:
         # s3/gs/gcs filesystem expects paths of the form `bucket/path`
         return parsed_url.netloc + parsed_url.path
 
@@ -125,7 +125,7 @@ class FilesystemResolver(object):
                     lambda url=self._dataset_url, user=user: \
                     connector.hdfs_connect_namenode(urlparse(url), hdfs_driver, user=user)
 
-        elif self._parsed_dataset_url.scheme == 's3':
+        elif self._parsed_dataset_url.scheme in ('s3', 's3a', 's3n'):
             # Case 5
             # S3 support requires s3fs to be installed
             try:


### PR DESCRIPTION
s3, s3a and s3n url protocols can be explicitly specified when saving petatorm datasets.

Fixed a bug on petastorm dataset write execution path previously preventing writing directly to s3 buckets.

Tested: modified `examples/generate_external_dataset.py` and `examples/python_hello_world.py` to write/read from s3 bucket using s3a and s3n buckets (wasn't able to properly configure s3 authentication to check that). Was able to write/read data successfully.