### PR TITLE
Bugfix: S3FSWrapper is deprecated at s3fs 0.5.0

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,7 @@ Release notes
 Release 0.9.7 (unreleased)
 ==========================
 
+- `PR 611 <https://github.com/uber/petastorm/pull/611>`_: Bugfix: S3FSWrapper is deprecated at s3fs 0.5.0
 
 Release 0.9.6
 ==========================

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,7 +7,7 @@ Release notes
 Release 0.9.7 (unreleased)
 ==========================
 
-- `PR 611 <https://github.com/uber/petastorm/pull/611>`_: Bugfix: S3FSWrapper is deprecated at s3fs 0.5.0
+- `PR 611 <https://github.com/uber/petastorm/pull/611>`_: Bugfix: S3FSWrapper is deprecated at s3fs 0.5.0. Minimal s3fs version required by petastorm wheel is now 0.5.0.
 
 Release 0.9.6
 ==========================

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -138,9 +138,9 @@ class FilesystemResolver(object):
                 raise ValueError('URLs must be of the form s3://bucket/path')
 
             fs = s3fs.S3FileSystem(config_kwargs=s3_config_kwargs)
-            self._filesystem = pyarrow.filesystem.S3FSWrapper(fs)
-            self._filesystem_factory = lambda: pyarrow.filesystem.S3FSWrapper(
-                s3fs.S3FileSystem(config_kwargs=s3_config_kwargs)
+            self._filesystem = fs
+            self._filesystem_factory = lambda: s3fs.S3FileSystem(
+                config_kwargs=s3_config_kwargs
             )
 
         elif self._parsed_dataset_url.scheme in ['gs', 'gcs']:

--- a/petastorm/tests/test_fs_utils.py
+++ b/petastorm/tests/test_fs_utils.py
@@ -15,9 +15,10 @@ import unittest
 
 import dill
 import mock
-from pyarrow.filesystem import LocalFileSystem, S3FSWrapper
+from pyarrow.filesystem import LocalFileSystem
 from pyarrow.lib import ArrowIOError
 from six.moves.urllib.parse import urlparse
+import s3fs
 
 from petastorm.fs_utils import FilesystemResolver, get_filesystem_and_path_or_paths
 from petastorm.gcsfs_helpers.gcsfs_wrapper import GCSFSWrapper
@@ -178,7 +179,7 @@ class FilesystemResolverTest(unittest.TestCase):
 
     def test_s3_url(self):
         suj = FilesystemResolver('s3://bucket{}'.format(ABS_PATH), self._hadoop_configuration, connector=self.mock)
-        self.assertTrue(isinstance(suj.filesystem(), S3FSWrapper))
+        self.assertTrue(isinstance(suj.filesystem(), s3fs.S3FileSystem))
         self.assertEqual('bucket', suj.parsed_dataset_url().netloc)
         self.assertEqual('bucket' + ABS_PATH, suj.get_dataset_path())
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ EXTRA_REQUIRE = {
         'alabaster>=0.7.11'
     ],
     'opencv': ['opencv-python>=3.2.0.6'],
+    's3fs': ['s3fs>=0.5.0'],
     'tf': ['tensorflow>=1.14.0'],
     'tf_gpu': ['tensorflow-gpu>=1.14.0'],
     'test': [


### PR DESCRIPTION
Enforce the minimal s3fs version at which S3FSWrapper is not needed. Fixes #609.