### PR TITLE
Raising an error if an empty list of columns is selected by a user

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,8 @@ Release 0.9.7 (unreleased)
 ==========================
 
 - `PR 611 <https://github.com/uber/petastorm/pull/611>`_: Bugfix: S3FSWrapper is deprecated at s3fs 0.5.0. Minimal s3fs version required by petastorm wheel is now 0.5.0.
+- `PR 615 <https://github.com/uber/petastorm/pull/615>`_: Raising an error if an empty list of columns is selected by a user.
+
 
 Release 0.9.6
 ==========================

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -421,6 +421,8 @@ class Reader(object):
             fields = schema_fields if isinstance(schema_fields, collections.Iterable) else None
 
         storage_schema = stored_schema.create_schema_view(fields) if fields else stored_schema
+        if len(storage_schema.fields) == 0:
+            raise RuntimeError(f"No fields matching the criteria '{fields}' were found in the dataset {dataset_path}.")
         if transform_spec:
             self.schema = transform_schema(storage_schema, transform_spec)
         else:

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -147,11 +147,8 @@ def test_invalid_column_name(scalar_dataset, reader_factory):
     all_fields = list(scalar_dataset.data[0].keys())
     bad_field = _get_bad_field_name(all_fields)
     requested_fields = [bad_field]
-
-    with reader_factory(scalar_dataset.url, schema_fields=requested_fields) as reader:
-        with pytest.raises(StopIteration):
-            sample = next(reader)._asdict()
-            assert not sample
+    with pytest.raises(RuntimeError, match=f"No fields matching the criteria.*{bad_field}.*"):
+        reader_factory(scalar_dataset.url, schema_fields=requested_fields)
 
 
 @pytest.mark.parametrize('reader_factory', _D)
@@ -165,8 +162,7 @@ def test_invalid_and_valid_column_names(scalar_dataset, reader_factory):
     with reader_factory(scalar_dataset.url, schema_fields=requested_fields) as reader:
         sample = next(reader)._asdict()
         assert len(sample) == 1
-        with pytest.raises(KeyError):
-            assert sample[bad_field] == ""
+        assert bad_field not in sample
 
 
 @pytest.mark.parametrize('reader_factory', _D)


### PR DESCRIPTION
Makes it easier to detect user logic error, as it makes no sense to create a reader that loads no data from storage.