### PR TITLE
Sort During URL Normalization

### DIFF
--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -50,7 +50,7 @@ def normalize_dataset_url_or_urls(dataset_url_or_urls):
     if isinstance(dataset_url_or_urls, list):
         if not dataset_url_or_urls:
             raise ValueError('dataset url list must be non-empty.')
-        return [normalize_dir_url(url) for url in dataset_url_or_urls]
+        return list(sorted(normalize_dir_url(url) for url in dataset_url_or_urls))
     else:
         return normalize_dir_url(dataset_url_or_urls)
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -117,7 +117,7 @@ def test_row_order(spark_test_ctx):
     ) as tf_dataset:
         expected_order = list(range(n_rows))
         actual_order = np.concatenate(
-            [batch.id.numpy() for batch in tf_dataset]
+            [batch.id.numpy() for batch in iter(tf_dataset)]
         ).ravel().tolist()
         assert expected_order == actual_order
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -105,6 +105,23 @@ def test_primitive(spark_test_ctx):
     assert np.object_ == ts.bin_col.dtype.type
 
 
+def test_row_order(spark_test_ctx):
+    n_rows = 10
+    df = spark_test_ctx.spark.range(n_rows)
+    spark_converter = make_spark_converter(df)
+    with spark_converter.make_tf_dataset(
+        batch_size=2,
+        shuffle_row_groups=False,
+        workers_count=1,
+        num_epochs=1,
+    ) as tf_dataset:
+        expected_order = list(range(n_rows))
+        actual_order = np.concatenate(
+            [batch.id.numpy() for batch in tf_dataset]
+        ).ravel().tolist()
+        assert expected_order == actual_order
+
+
 @create_tf_graph
 def test_array_field(spark_test_ctx):
     @pandas_udf('array<float>')

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -105,21 +105,26 @@ def test_primitive(spark_test_ctx):
     assert np.object_ == ts.bin_col.dtype.type
 
 
+@create_tf_graph
 def test_row_order(spark_test_ctx):
     n_rows = 10
+    batch_size = 2
     df = spark_test_ctx.spark.range(n_rows)
     spark_converter = make_spark_converter(df)
     with spark_converter.make_tf_dataset(
-            batch_size=2,
+            batch_size=batch_size,
             shuffle_row_groups=False,
             workers_count=1,
             num_epochs=1
     ) as tf_dataset:
-        expected_order = list(range(n_rows))
-        actual_order = np.concatenate(
-            [batch.id.numpy() for batch in iter(tf_dataset)]
-        ).ravel().tolist()
-        assert expected_order == actual_order
+        expected_batches = np.split(np.array(range(n_rows)), n_rows // batch_size)
+        tf_iterator = tf_dataset.make_one_shot_iterator()
+        next_op = tf_iterator.get_next()
+        with tf.Session() as sess:
+            for i in range(len(expected_batches)):
+                expected_batch = expected_batches[i]
+                actual_batch = sess.run(next_op).id
+                np.testing.assert_array_equal(expected_batch, actual_batch)
 
 
 @create_tf_graph

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -109,7 +109,12 @@ def test_row_order(spark_test_ctx):
     n_rows = 10
     df = spark_test_ctx.spark.range(n_rows)
     spark_converter = make_spark_converter(df)
-    with spark_converter.make_tf_dataset(batch_size=2, shuffle_row_groups=False, workers_count=1, num_epochs=1) as tf_dataset:
+    with spark_converter.make_tf_dataset(
+        batch_size=2,
+        shuffle_row_groups=False,
+        workers_count=1,
+        num_epochs=1
+    ) as tf_dataset:
         expected_order = list(range(n_rows))
         actual_order = np.concatenate(
             [batch.id.numpy() for batch in tf_dataset]

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -110,10 +110,10 @@ def test_row_order(spark_test_ctx):
     df = spark_test_ctx.spark.range(n_rows)
     spark_converter = make_spark_converter(df)
     with spark_converter.make_tf_dataset(
-        batch_size=2,
-        shuffle_row_groups=False,
-        workers_count=1,
-        num_epochs=1
+            batch_size=2,
+            shuffle_row_groups=False,
+            workers_count=1,
+            num_epochs=1
     ) as tf_dataset:
         expected_order = list(range(n_rows))
         actual_order = np.concatenate(

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -109,12 +109,7 @@ def test_row_order(spark_test_ctx):
     n_rows = 10
     df = spark_test_ctx.spark.range(n_rows)
     spark_converter = make_spark_converter(df)
-    with spark_converter.make_tf_dataset(
-        batch_size=2,
-        shuffle_row_groups=False,
-        workers_count=1,
-        num_epochs=1,
-    ) as tf_dataset:
+    with spark_converter.make_tf_dataset(batch_size=2, shuffle_row_groups=False, workers_count=1, num_epochs=1) as tf_dataset:
         expected_order = list(range(n_rows))
         actual_order = np.concatenate(
             [batch.id.numpy() for batch in tf_dataset]


### PR DESCRIPTION
I have the following script that converts a Spark DataFrame into a TensorFlow Dataset:

```python
from tempfile import TemporaryDirectory

from petastorm.spark import make_spark_converter, SparkDatasetConverter
from pyspark.sql import SparkSession

spark = (
    SparkSession.builder
        .master("local[2]")
        .config(SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF, f"file://{TemporaryDirectory().name}")
        .getOrCreate()
)

df = spark.createDataFrame(
    data=[[i] for i in range(10)],
    schema=['index']
)

spark_converter = make_spark_converter(df)
for url in spark_converter.file_urls:
    print(url)

with spark_converter.make_tf_dataset(
    batch_size=2,
    shuffle_row_groups=False,
    workers_count=1,
    num_epochs=1,
) as tf_dataset:
    for batch in tf_dataset:
        print(batch.index)
```

Sometimes it outputs:
```
tf.Tensor([0 1], shape=(2,), dtype=int64)
tf.Tensor([2 3], shape=(2,), dtype=int64)
tf.Tensor([4 5], shape=(2,), dtype=int64)
tf.Tensor([6 7], shape=(2,), dtype=int64)
tf.Tensor([8 9], shape=(2,), dtype=int64)
```

But other times it outputs:
```
tf.Tensor([5 6], shape=(2,), dtype=int64)
tf.Tensor([7 8], shape=(2,), dtype=int64)
tf.Tensor([9 0], shape=(2,), dtype=int64)
tf.Tensor([1 2], shape=(2,), dtype=int64)
tf.Tensor([3 4], shape=(2,), dtype=int64)
```

I've found that the first happens when `spark_converter.file_urls` is:
```
[
    file://.../part-00000-7c8be26f-e43d-4432-8596-da41e883de93-c000.parquet,
    file://.../part-00001-7c8be26f-e43d-4432-8596-da41e883de93-c000.parquet
]
```

And the second happens when `spark_converter.file_urls` is:
```
[
    file://.../part-00001-1eb56383-3219-4545-8f85-e395ad1a5468-c000.parquet,
    file://.../part-00000-1eb56383-3219-4545-8f85-e395ad1a5468-c000.parquet
]
```

Sorting the file urls fixes this though, and results in a deterministic read order.