### PR TITLE
Support on-premise s3-compatible storage.

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,7 @@ Release notes
 Release 0.9.8 (unreleased)
 ==========================
 - `PR 617 <https://github.com/uber/petastorm/pull/617>`_: Deprecating `pyarrow_serialize` argument of `petastorm.make_reader`.
+- `PR 625 <https://github.com/uber/petastorm/pull/625>`_: Support on-premise s3-compatible storage.
 
 
 Release 0.9.7

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,7 +8,6 @@ Release notes
 Release 0.9.8 (unreleased)
 ==========================
 - `PR 617 <https://github.com/uber/petastorm/pull/617>`_: Deprecating `pyarrow_serialize` argument of `petastorm.make_reader`.
-- `PR 625 <https://github.com/uber/petastorm/pull/625>`_: Support on-premise s3-compatible storage.
 - `PR 625 <https://github.com/uber/petastorm/pull/625>`_: Support on-premise s3-compatible storage. User can now pass an instance of pyarrow filesystem to `make_reader` and `make_batch_reader` functions.
 
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,7 @@ Release 0.9.8 (unreleased)
 ==========================
 - `PR 617 <https://github.com/uber/petastorm/pull/617>`_: Deprecating `pyarrow_serialize` argument of `petastorm.make_reader`.
 - `PR 625 <https://github.com/uber/petastorm/pull/625>`_: Support on-premise s3-compatible storage.
+- `PR 625 <https://github.com/uber/petastorm/pull/625>`_: Support on-premise s3-compatible storage. User can now pass an instance of pyarrow filesystem to `make_reader` and `make_batch_reader` functions.
 
 
 Release 0.9.7

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -385,15 +385,19 @@ def get_schema(dataset):
     return schema
 
 
-def get_schema_from_dataset_url(dataset_url_or_urls, hdfs_driver='libhdfs3'):
+def get_schema_from_dataset_url(dataset_url_or_urls, hdfs_driver='libhdfs3', s3_config_kwargs=None, filesystem=None):
     """Returns a :class:`petastorm.unischema.Unischema` object loaded from a dataset specified by a url.
 
     :param dataset_url_or_urls: a url to a parquet directory or a url list (with the same scheme) to parquet files.
     :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
         libhdfs (java through JNI) or libhdfs3 (C++)
+    :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
+    :param fileystem: the filesystem to use.
     :return: A :class:`petastorm.unischema.Unischema` object
     """
-    fs, path_or_paths = get_filesystem_and_path_or_paths(dataset_url_or_urls, hdfs_driver)
+    fs, path_or_paths = get_filesystem_and_path_or_paths(dataset_url_or_urls, hdfs_driver,
+                                                         s3_config_kwargs=s3_config_kwargs,
+                                                         filesystem=filesystem)
 
     dataset = pq.ParquetDataset(path_or_paths, filesystem=fs, validate_schema=False, metadata_nthreads=10)
 

--- a/petastorm/etl/dataset_metadata.py
+++ b/petastorm/etl/dataset_metadata.py
@@ -392,7 +392,7 @@ def get_schema_from_dataset_url(dataset_url_or_urls, hdfs_driver='libhdfs3', s3_
     :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
         libhdfs (java through JNI) or libhdfs3 (C++)
     :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
-    :param fileystem: the filesystem to use.
+    :param fileystem: the ``pyarrow.FileSystem`` to use.
     :return: A :class:`petastorm.unischema.Unischema` object
     """
     fs, path_or_paths = get_filesystem_and_path_or_paths(dataset_url_or_urls, hdfs_driver,

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -220,7 +220,8 @@ def get_filesystem_and_path_or_paths(url_or_urls, hdfs_driver='libhdfs3', s3_con
         if parsed_url.scheme != first_scheme or parsed_url.netloc != first_netloc:
             raise ValueError('The dataset url list must contain url with the same scheme and netloc.')
 
-    fs = filesystem or FilesystemResolver(url_list[0], hdfs_driver=hdfs_driver, s3_config_kwargs=s3_config_kwargs).filesystem()
+    fs = filesystem or FilesystemResolver(
+        url_list[0], hdfs_driver=hdfs_driver, s3_config_kwargs=s3_config_kwargs).filesystem()
     path_list = [get_dataset_path(parsed_url) for parsed_url in parsed_url_list]
 
     if isinstance(url_or_urls, list):

--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -63,6 +63,7 @@ class FilesystemResolver(object):
         :param hdfs_driver: A string denoting the hdfs driver to use (if using a dataset on hdfs). Current choices are
         libhdfs (java through JNI) or libhdfs3 (C++)
         :param user: String denoting username when connecting to HDFS. None implies login user.
+        :param s3_config_kwargs: The config passed to S3FileSystem.
         """
         # Cache both the original URL and the resolved, urlparsed dataset_url
         self._dataset_url = dataset_url
@@ -198,7 +199,7 @@ class FilesystemResolver(object):
                            'anti-pickling protection')
 
 
-def get_filesystem_and_path_or_paths(url_or_urls, hdfs_driver='libhdfs3', s3_config_kwargs=None):
+def get_filesystem_and_path_or_paths(url_or_urls, hdfs_driver='libhdfs3', s3_config_kwargs=None, filesystem=None):
     """
     Given a url or url list, return a tuple ``(filesystem, path_or_paths)``
     ``filesystem`` is created from the given url(s), and ``path_or_paths`` is a path or path list
@@ -219,7 +220,7 @@ def get_filesystem_and_path_or_paths(url_or_urls, hdfs_driver='libhdfs3', s3_con
         if parsed_url.scheme != first_scheme or parsed_url.netloc != first_netloc:
             raise ValueError('The dataset url list must contain url with the same scheme and netloc.')
 
-    fs = FilesystemResolver(url_list[0], hdfs_driver=hdfs_driver, s3_config_kwargs=s3_config_kwargs).filesystem()
+    fs = filesystem or FilesystemResolver(url_list[0], hdfs_driver=hdfs_driver, s3_config_kwargs=s3_config_kwargs).filesystem()
     path_list = [get_dataset_path(parsed_url) for parsed_url in parsed_url_list]
 
     if isinstance(url_or_urls, list):

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -124,7 +124,7 @@ def make_reader(dataset_url,
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
     :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
     :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
-    :param filesystem: A filesystem to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
+    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
     :return: A :class:`Reader` object
     """
     dataset_url = normalize_dir_url(dataset_url)
@@ -265,7 +265,7 @@ def make_batch_reader(dataset_url_or_urls,
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
     :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
     :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
-    :param filesystem: A filesystem to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
+    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
     :return: A :class:`Reader` object
     """
     dataset_url_or_urls = normalize_dataset_url_or_urls(dataset_url_or_urls)

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -124,7 +124,8 @@ def make_reader(dataset_url,
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
     :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
     :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
-    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
+    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and
+        other filesystem configs if it's provided.
     :return: A :class:`Reader` object
     """
     dataset_url = normalize_dir_url(dataset_url)
@@ -265,7 +266,8 @@ def make_batch_reader(dataset_url_or_urls,
         here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
     :param s3_config_kwargs: dict of parameters passed to ``botocore.client.Config``
     :param zmq_copy_buffers: A bool indicating whether to use 0mq copy buffers with ProcessPool.
-    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and other filesystem configs if it's provided.
+    :param filesystem: An instance of ``pyarrow.FileSystem`` to use. Will ignore s3_config_kwargs and
+        other filesystem configs if it's provided.
     :return: A :class:`Reader` object
     """
     dataset_url_or_urls = normalize_dataset_url_or_urls(dataset_url_or_urls)

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -17,7 +17,6 @@ import logging
 import warnings
 
 import six
-from six.moves.urllib.parse import urlparse
 from pyarrow import parquet as pq
 
 from petastorm.arrow_reader_worker import ArrowReaderWorker
@@ -25,7 +24,7 @@ from petastorm.cache import NullCache
 from petastorm.errors import NoDataAvailableError
 from petastorm.etl import dataset_metadata, rowgroup_indexing
 from petastorm.etl.dataset_metadata import PetastormMetadataError, infer_or_load_unischema
-from petastorm.fs_utils import get_filesystem_and_path_or_paths, normalize_dir_url, get_dataset_path
+from petastorm.fs_utils import get_filesystem_and_path_or_paths, normalize_dir_url
 from petastorm.local_disk_arrow_table_cache import LocalDiskArrowTableCache
 from petastorm.local_disk_cache import LocalDiskCache
 from petastorm.ngram import NGram


### PR DESCRIPTION
Support on-premise s3-compatible storage. User can now pass an instance of pyarrow filesystem to `make_reader` and `make_batch_reader` functions.