### PR TITLE
bug with weighted_sampling_reader and pytorch

### DIFF
--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -199,7 +199,7 @@ class DataLoader(LoaderBase):
             _sanitize_pytorch_types(row_as_dict)
 
             # Add rows to shuffling buffer
-            if not self.reader.is_batched_reader:
+            if not self.reader.batched_output:
                 self._shuffling_buffer.add_many([row_as_dict])
             else:
                 # Transposition:
@@ -330,7 +330,7 @@ class BatchedDataLoader(LoaderBase):
 
             # Add rows to shuffling buffer
             for k, v in row_as_dict.items():
-                if not self.reader.is_batched_reader:
+                if not self.reader.batched_output:
                     row_as_dict[k] = self.transform_fn([v])
                 else:
                     row_as_dict[k] = self.transform_fn(v)

--- a/petastorm/weighted_sampling_reader.py
+++ b/petastorm/weighted_sampling_reader.py
@@ -102,9 +102,15 @@ class WeightedSamplingReader(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def stop(self):
         for reader in self._readers:
             reader.stop()
 
+    def join(self):
         for reader in self._readers:
             reader.join()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        self.join()
+

--- a/petastorm/weighted_sampling_reader.py
+++ b/petastorm/weighted_sampling_reader.py
@@ -113,4 +113,3 @@ class WeightedSamplingReader(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
         self.join()
-


### PR DESCRIPTION
- petastorm.pytorch.DataLoader expects the field is_batched_reader in the reader. WeightedSamplingReader does not have this field. It seems to be replaced by the property: batched_output.

- petastorm.pytorch.DataLoader expects the functions stop() and join() from the reader. WeightedSamplingReader does not have these functions. This PR adds these functions.