### PR TITLE
Fixed docstring in NGram class: timestamp_field argument illustration…

### DIFF
--- a/petastorm/ngram.py
+++ b/petastorm/ngram.py
@@ -40,7 +40,7 @@ class NGram(object):
     >>>       TestSchema.sensor_name],
     >>> }
     >>> delta_threshold = 5
-    >>> timestamp_field = 'id'
+    >>> timestamp_field = TestSchema.id
 
       - The data being:
 
@@ -60,7 +60,7 @@ class NGram(object):
     >>>          TestSchema.sensor_name],
     >>> }
     >>> delta_threshold = 4
-    >>> timestamp_field = 'id'
+    >>> timestamp_field = TestSchema.id
 
       - The data being:
 


### PR DESCRIPTION
The usage examples shown in the docstring of the NGram class have an error. Entering the timestamp parameter as a string (i.e. 'id') doesn't work. It should be a Unischema Field. (i.e. entered as TestSchema.id). This pull request reflects the necessary change in the docstring.