### PR TITLE
Add unit tests for compress in random shuffling buffer

### DIFF
--- a/petastorm/reader_impl/pytorch_shuffling_buffer.py
+++ b/petastorm/reader_impl/pytorch_shuffling_buffer.py
@@ -260,7 +260,7 @@ class BatchedRandomShufflingBuffer(BatchedShufflingBufferBase):
             # Before we can append a new batch, we compress the remaining samples
             for k, v in enumerate(self._items):
                 # We need to clone the right-side to avoid racing conditions
-                self._items[k][:self.size] = self._items[k][self._random_indices[self.next_sample_head:]].clone()
+                self._items[k][:self._size] = self._items[k][self._random_indices[self.next_sample_head:]].clone()
         self._random_indices = None
         self.next_sample_head = 0
 


### PR DESCRIPTION
~Compress remaining shuffling buffer should use remained size, that is, `self._size`.~

`self.size` actually is a property decorator defined afterwards.
I just change it to keep consistent with other places of code to improve readability.

Also, I added some unit tests to check compress results.