### PR TITLE
Security fix for arbitrary code execution.

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,6 +12,8 @@ Release 0.11.2 (unreleased)
 - `PR 694 <https://github.com/uber/petastorm/pull/694>`_ (resolves issue
   `#691 <https://github.com/uber/petastorm/issues/691>`_ ):
   Enable extraction of storage_options from input url.
+- `PR 640 <https://github.com/uber/petastorm/pull/640>`_: Security fix for arbitrary code execution (affects depickling of Unischema loaded from petastorm datasets).
+
 
 Release 0.11.1
 ===========================

--- a/petastorm/tests/test_ngram_end_to_end.py
+++ b/petastorm/tests/test_ngram_end_to_end.py
@@ -1,5 +1,3 @@
-# Disabling lint bad-continuation due to lint issues between python 2.7 and python 3.6
-
 #  Copyright (c) 2017-2018 Uber Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Based on #637: whitelists a set of packages which classes can be unpickled. Prevents unpickling a malicious class that may invoke `os.execute` or a similar other malicious function calls.