### PR TITLE
Tests: fix the unit test of batched dataloader with in-memory cache

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,7 @@ Release notes
 
 Release 0.9.9 (unreleased)
 ==========================
+- `PR 643 <https://github.com/uber/petastorm/pull/643>`_: Tests: fix the unit test of batched dataloader with in-memory cache.
 
 
 Release 0.9.8

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -291,7 +291,8 @@ class BatchedDataLoader(LoaderBase):
           instance. If set to 0, no shuffling will be done.
         :param inmemory_cache_all: This is an boolean that indicates whether the data should be
             cached in memory or not. When this cache is enabled, expect smaller than requested
-            batch size on the epoch boundaries.
+            batch size on the epoch boundaries. Enabling this cache also requres that shuffling_queue_capacity to be
+            large enough to hold all data.
         :param num_epochs: Number of epochs to load when in memory cache is enabled. If
             set to None, loader will loads batches indefinitely.
         """

--- a/petastorm/tests/test_pytorch_dataloader.py
+++ b/petastorm/tests/test_pytorch_dataloader.py
@@ -227,7 +227,8 @@ def test_mem_cache_num_epochs_without_mem_cache_error(two_columns_non_petastorm_
             BatchedDataLoader(reader, num_epochs=2)
 
 
-@pytest.mark.parametrize('shuffling_queue_capacity', [20, 0])
+# shuffling_queue_capacity should be 0 or equal/greater to number of rows in file (50 in this test)
+@pytest.mark.parametrize('shuffling_queue_capacity', [50, 0])
 @pytest.mark.parametrize('reader_factory', [make_batch_reader, make_reader])
 @pytest.mark.parametrize('num_epochs', [1, 2, 3, None])
 def test_batched_data_loader_with_in_memory_cache(two_columns_non_petastorm_dataset,
@@ -235,7 +236,8 @@ def test_batched_data_loader_with_in_memory_cache(two_columns_non_petastorm_data
                                                   reader_factory,
                                                   num_epochs):
     batch_size = 10
-    extra_loader_params = dict(inmemory_cache_all=True, num_epochs=num_epochs)
+    extra_loader_params = dict(inmemory_cache_all=True, num_epochs=num_epochs,
+                               shuffling_queue_capacity=shuffling_queue_capacity)
     extra_reader_params = dict(num_epochs=1)
 
     with reader_factory(two_columns_non_petastorm_dataset.url,


### PR DESCRIPTION
Also add comments of setting shuffling_queue_capacity correctly when
enablding in memory cache.

Fix #642 