### PR TITLE
Fix mypy test: removing np.bool from tf_utils numpy-to-tf dtype conversion

### DIFF
--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -25,7 +25,6 @@ import tensorflow.compat.v1 as tf  # pylint: disable=import-error
 
 # Mapping of identical datatypes in numpy-ish and tensorflow-ish
 _NUMPY_TO_TF_DTYPES_MAPPING = {
-    np.bool: tf.bool,
     np.int8: tf.int8,
     np.int16: tf.int16,
     np.int32: tf.int32,


### PR DESCRIPTION
A proper numpy dtype to use is `np.bool_` and not `np.bool`. `np.bool_` is already present in the numpy/tf mapping table.
This fixes mypy static check that would fail if we upgrade pyarrow to version 2 or higher.