### PR TITLE
fix  get_dataset_path() in fs_utils.py

### DIFF
--- a/petastorm/fs_utils.py
+++ b/petastorm/fs_utils.py
@@ -16,6 +16,7 @@ import logging
 import pyarrow
 import six
 from six.moves.urllib.parse import urlparse
+import platform
 
 from petastorm.gcsfs_helpers.gcsfs_wrapper import GCSFSWrapper
 from petastorm.hdfs.namenode import HdfsNamenodeResolver, HdfsConnector
@@ -32,6 +33,9 @@ def get_dataset_path(parsed_url):
     if parsed_url.scheme.lower() in ['s3', 's3a', 's3n', 'gs', 'gcs']:
         # s3/gs/gcs filesystem expects paths of the form `bucket/path`
         return parsed_url.netloc + parsed_url.path
+
+    if parsed_url.scheme.lower() in ['file'] and "Windows" in platform.system():
+        return parsed_url.path[1:]
 
     return parsed_url.path
 


### PR DESCRIPTION
version:
Windows 10
Python 3.7.0
petastorm 0.9.8
pyarrow 3.0.0

```
from petastorm import make_reader

reader = make_reader('file:///D:/test/test.parquet') 
print(reader)
```
The following error occurred when I ran the above code under Windows.

![picture](https://user-images.githubusercontent.com/40270581/114272319-4d4ac280-9a48-11eb-95e6-ed490a4e088d.jpg)


The image above shows that there is an extra '/' at the beginning of the file path.
So I deleted the extra '/' .