### PR TITLE
tf_dataset: add unit test to verify repeat() works after cache()

### DIFF
--- a/petastorm/tests/test_tf_dataset.py
+++ b/petastorm/tests/test_tf_dataset.py
@@ -101,8 +101,8 @@ def test_with_one_shot_iterator(synthetic_dataset, reader_factory):
 @create_tf_graph
 def test_with_dataset_repeat(synthetic_dataset, reader_factory):
     """``tf.data.Dataset``'s ``repeat`` should not be used on ``make_petastorm_dataset`` due to high costs of
-    ``Reader initialization``. A user should use ``Reader`` built-in epochs support. Check that we raise an
-    error to alert of misuse."""
+    ``Reader initialization``. A user should use ``Reader`` built-in epochs support, or use
+    ``tf.data.Dataset``'s ``cache``. Check that we raise an error to alert of misuse."""
     with reader_factory(synthetic_dataset.url) as reader:
         dataset = make_petastorm_dataset(reader)
 
@@ -119,6 +119,34 @@ def test_with_dataset_repeat(synthetic_dataset, reader_factory):
 
             with pytest.raises(tf.errors.UnknownError, match=r'.*Multiple iterations.*'):
                 sess.run(iterator)
+
+
+@pytest.mark.forked
+@pytest.mark.parametrize('reader_factory', ALL_READER_FLAVOR_FACTORIES)
+@create_tf_graph
+def test_with_dataset_repeat_after_cache(synthetic_dataset, reader_factory):
+    """ Check if ``tf.data.Dataset``'s ``repeat`` works after ``tf.data.Dataset``'s ``cache``."""
+    epochs = 3
+    with reader_factory(synthetic_dataset.url, schema_fields=[TestSchema.id]) as reader:
+        dataset = make_petastorm_dataset(reader)
+        dataset = dataset.cache()
+        dataset = dataset.repeat(epochs)
+        iterator = dataset.make_one_shot_iterator()
+        it_op = iterator.get_next()
+        # Check if dataset generates same result in every epoch.
+        with tf.Session() as sess:
+            for _ in range(epochs):
+                actual_res = []
+                for _, _ in enumerate(synthetic_dataset.data):
+                    actual = sess.run(it_op)._asdict()
+                    actual_res.append(actual["id"])
+                expected_res = list(range(len(synthetic_dataset.data)))
+                # sort dataset output since row_groups are shuffled from reader.
+                np.testing.assert_equal(sorted(actual_res), expected_res)
+
+            # Exhausted all epochs. Fetching next value should trigger OutOfRangeError
+            with pytest.raises(tf.errors.OutOfRangeError):
+                sess.run(it_op)
 
 
 @pytest.mark.forked

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -368,8 +368,9 @@ def make_petastorm_dataset(reader):
                 # (nor want to do that) since this is an expensive operation. num_epochs is a more efficient way
                 # to do this.
                 raise RuntimeError('Multiple iterations over make_petastorm_dataset are not supported. '
-                                   'Multiple iterations can be triggered by calling \'repeat\' method of Datset class.'
-                                   'Use Reader\'s num_epochs contructor arguments to set number of iterations.')
+                                   'Use Reader\'s num_epochs contructor arguments to set number of iterations,'
+                                   'or use tf.data.Dataset\'s cache() function to cache data of first iteration before'
+                                   'calling \'repeat\' method of Datset class.')
             for row in reader:
                 yield _sanitize_field_tf_types(row)
 


### PR DESCRIPTION
We can cache first iteration result then use repeat() to do multiple
epochs.