### PR TITLE
Allow opening parquet stores with unsupported types.

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,7 +6,10 @@ Release notes
 
 Release 0.11.1 (unreleased)
 ===========================
-
+- `PR 686 <https://github.com/uber/petastorm/pull/686>`_ (resolves issue
+  `#685 <https://github.com/uber/petastorm/issues/685>`_ ):
+  Silenty omit fields that have unsupported types. Previously were failing
+  loudly making parquet stores with such fields unusable with Petastorm.
 
 Release 0.11.0
 ===========================

--- a/petastorm/tests/test_common.py
+++ b/petastorm/tests/test_common.py
@@ -199,7 +199,6 @@ def create_test_scalar_dataset(output_url, num_rows, num_files=4, spark=None, pa
                   'float64': np.float64(i) * .66}
         if not is_list_of_scalar_broken:
             result['int_fixed_size_list'] = np.arange(1 + i, 10 + i).astype(np.int32)
-        result = OrderedDict(sorted(result.items(), key=lambda item: item[0]))
         return result
 
     expected_data = [expected_row(i) for i in range(num_rows)]
@@ -213,8 +212,9 @@ def create_test_scalar_dataset(output_url, num_rows, num_files=4, spark=None, pa
         row['timestamp'] = row['timestamp'].replace(tzinfo=pytz.UTC)
         if not is_list_of_scalar_broken:
             row['int_fixed_size_list'] = row['int_fixed_size_list'].tolist()
+        row['nested_struct'] = {'nested_int': 0}
 
-    rows = [Row(**row) for row in expected_data_as_scalars]
+    rows = [Row(**OrderedDict(sorted(row.items(), key=lambda item: item[0]))) for row in expected_data_as_scalars]
 
     maybe_int_fixed_size_list_field = [StructField('int_fixed_size_list', ArrayType(IntegerType(), False), False)] \
         if not is_list_of_scalar_broken else []
@@ -229,6 +229,7 @@ def create_test_scalar_dataset(output_url, num_rows, num_files=4, spark=None, pa
             StructField('id_div_700', IntegerType(), False),
         ] + maybe_int_fixed_size_list_field +
         [
+            StructField('nested_struct', StructType([StructField('nested_int', IntegerType(), True)])),
             StructField('string', StringType(), False),
             StructField('string2', StringType(), False),
             StructField('timestamp', TimestampType(), False),

--- a/petastorm/tests/test_unischema.py
+++ b/petastorm/tests/test_unischema.py
@@ -398,7 +398,7 @@ def test_arrow_schema_convertion_fail():
     mock_dataset = _mock_parquet_dataset([], arrow_schema)
 
     with pytest.raises(ValueError, match='Cannot auto-create unischema due to unsupported column type'):
-        Unischema.from_arrow_schema(mock_dataset)
+        Unischema.from_arrow_schema(mock_dataset, omit_unsupported_fields=False)
 
 
 def test_arrow_schema_arrow_1644_list_of_struct():

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -300,7 +300,7 @@ class Unischema(object):
         return self._get_namedtuple()(*args, **kargs)
 
     @classmethod
-    def from_arrow_schema(cls, parquet_dataset, omit_unsupported_fields=False):
+    def from_arrow_schema(cls, parquet_dataset, omit_unsupported_fields=True):
         """
         Convert an apache arrow schema into a unischema object. This is useful for datasets of only scalars
         which need no special encoding/decoding. If there is an unsupported type in the arrow schema, it will


### PR DESCRIPTION
Previously, an error was raised when an unsupported type (e.g. nested structure) was found in the datasource. Relaxing the constraint so that fields with unknown types would be silently ignored - simply won't show up in the loaded data.