### PR TITLE
Fix a failure when reading data from a parquet file (and not a parquet directory)

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,9 @@ Release notes
 
 Release 0.11.1 (unreleased)
 ===========================
+- `PR 687 <https://github.com/uber/petastorm/pull/687>`_ (resolves issue
+  `#684 <https://github.com/uber/petastorm/issues/684>`_ ):
+  Fix a failure when reading data from a parquet file (and not a parquet directory).
 
 
 Release 0.11.0

--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -174,7 +174,10 @@ class PyDictReaderWorker(WorkerBase):
         # pyarrow would fail if we request a column names that the dataset is partitioned by, so we strip them from
         # the `columns` argument.
         partitions = self._dataset.partitions
-        column_names = set(field.name for field in self._schema.fields.values()) - partitions.partition_names
+        # self._dataset.partitions is None, if make_reader is created directly from a parquet file
+        # (and not a directory with *.parquet files)
+        partition_names = partitions.partition_names if partitions else set()
+        column_names = set(field.name for field in self._schema.fields.values()) - partition_names
 
         all_rows = self._read_with_shuffle_row_drop(piece, pq_file, column_names, shuffle_row_drop_range)
 

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import glob
 import tempfile
 import operator
 import os
@@ -109,6 +109,17 @@ def test_simple_read(synthetic_dataset, reader_factory):
     """Just a bunch of read and compares of all values to the expected values using the different reader pools"""
     with reader_factory(synthetic_dataset.url) as reader:
         _check_simple_reader(reader, synthetic_dataset.data)
+
+
+@pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES)
+def test_simple_read_from_parquet_file(synthetic_dataset, reader_factory):
+    """See if we can read data when a single parquet file is specified instead of a parquet directory"""
+    assert synthetic_dataset.url.startswith('file://')
+    path = synthetic_dataset.url[len('file://'):]
+    one_parquet_file = glob.glob(f'{path}/**/*.parquet')[0]
+    with reader_factory(f"file://{one_parquet_file}") as reader:
+        all_data = list(reader)
+        assert len(all_data) > 0
 
 
 @pytest.mark.parametrize('reader_factory', [

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -72,7 +72,7 @@ def test_simple_read(scalar_dataset, reader_factory):
 
 
 @pytest.mark.parametrize('reader_factory', _D)
-def test_simple_read(scalar_dataset, reader_factory):
+def test_simple_read_from_a_single_file(scalar_dataset, reader_factory):
     """See if we can read data when a single parquet file is specified instead of a parquet directory"""
     assert scalar_dataset.url.startswith('file://')
     path = scalar_dataset.url[len('file://'):]

--- a/petastorm/tests/test_parquet_reader.py
+++ b/petastorm/tests/test_parquet_reader.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import glob
 import itertools
 
 import numpy as np
@@ -68,6 +69,18 @@ def test_simple_read(scalar_dataset, reader_factory):
     """Just a bunch of read and compares of all values to the expected values using the different reader pools"""
     with reader_factory(scalar_dataset.url) as reader:
         _check_simple_reader(reader, scalar_dataset.data)
+
+
+@pytest.mark.parametrize('reader_factory', _D)
+def test_simple_read(scalar_dataset, reader_factory):
+    """See if we can read data when a single parquet file is specified instead of a parquet directory"""
+    assert scalar_dataset.url.startswith('file://')
+    path = scalar_dataset.url[len('file://'):]
+    one_parquet_file = glob.glob(f'{path}/**.parquet')[0]
+
+    with reader_factory(f"file://{one_parquet_file}") as reader:
+        all_data = list(reader)
+        assert len(all_data) > 0
 
 
 @pytest.mark.parametrize('reader_factory', _D)


### PR DESCRIPTION


Code was crashing since ParquetDataset's (pyarrow) partition_names attribute was set to None when the ParquetDataset object instance was created from a parquet file and not parquet directory.