### PR TITLE
Python 3.9 isAlive -> is_alive compatibility fix

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,9 @@ Release notes
 
 Release 0.11.2 (unreleased)
 ===========================
+- `PR ??? <https://github.com/uber/petastorm/pull/???>`_ (resolves issue
+  `#692 <https://github.com/uber/petastorm/issues/692>`_ ):
+  Python 3.9 compatibility - use `Thread`'s `is_alive()` instead of `isAlive()`.
 
 
 Release 0.11.1

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -184,7 +184,7 @@ class ThreadPool(object):
     def join(self):
         """Block until all workers are terminated."""
         for w in self._workers:
-            if w.isAlive():
+            if w.is_alive():
                 w.join()
 
         if self._profiling_enabled:


### PR DESCRIPTION
Python 3.8 is the last version supporting isAlive method. It was renamed to is_alive. Resolves #692.