### PR TITLE
Use py3.9 for all CI tests, except one that uses 3.7

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,38 +26,50 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [config1, config2, config3, config4, config5]
+        config: [pyspark-2.4, tf-1.15, pyarrow-2.0, latest,  pyarrow-0.17.1, py39]
         include:
-        - config: config1
+        - config: pyspark-2.4
           PYARROW_VERSION: "2.0.0"
           NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "1.15.0"
+          TF_VERSION: "1.15.5"
           PYSPARK_VERSION: "2.4.4"
           ARROW_PRE_0_15_IPC_FORMAT: 1
-        - config: config2
+          PY: "3.7"
+        - config: tf-1.15
           PYARROW_VERSION: "2.0.0"
           NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "1.15.0"
+          TF_VERSION: "1.15.5"
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
-        - config: config3
+          PY: "3.7"
+        - config: pyarrow-2.0
           PYARROW_VERSION: "2.0.0"
           NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "2.1.0"
+          TF_VERSION: "2.5.0"
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
-        - config: config4
+          PY: "3.7"
+        - config: latest
           PYARROW_VERSION: "3.0.0"
           NUMPY_VERSION: "1.20.1"
-          TF_VERSION: "2.1.0"
+          TF_VERSION: "2.5.0"
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: "0"
-        - config: config5
+          PY: "3.7"
+        - config: pyarrow-0.17.1
           PYARROW_VERSION: "0.17.1"
           NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "2.1.0"
+          TF_VERSION: "2.5.0"
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
+          PY: "3.7"
+        - config: py39
+          PYARROW_VERSION: "3.0.0"
+          NUMPY_VERSION: "1.20.1"
+          TF_VERSION: "2.5.0"
+          PYSPARK_VERSION: "3.0.0"
+          ARROW_PRE_0_15_IPC_FORMAT: "0"
+          PY: "3.9"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -67,7 +79,7 @@ jobs:
       # Prepare
       - name: prepare
         run: |
-          export CI_IMAGE=selitvin/petastorm_ci_auto:ci-2020-07-01-00
+          export CI_IMAGE=selitvin/petastorm_ci_auto:ci-image-06-29-2021
           docker pull $CI_IMAGE
           docker images
           pip install -U codecov
@@ -80,11 +92,12 @@ jobs:
           export PYARROW_VERSION=${{matrix.PYARROW_VERSION}}
           export NUMPY_VERSION=${{matrix.NUMPY_VERSION}}
           export TF_VERSION=${{matrix.TF_VERSION}}
-          export PY="3.7"
+          export PY=${{matrix.PY}}
           export PYSPARK_VERSION=${{matrix.PYSPARK_VERSION}}
           export ARROW_PRE_0_15_IPC_FORMAT=${{matrix.ARROW_PRE_0_15_IPC_FORMAT}}
           export RUN="docker exec -e ARROW_PRE_0_15_IPC_FORMAT=$ARROW_PRE_0_15_IPC_FORMAT petastorm_ci bash /run_in_venv.sh ${PY}"
           export PYTEST="pytest --timeout=360 -v --color=yes --cov=./ --cov-report xml:coverage.xml"
+          $RUN pip install -U pip setuptools
           $RUN pip install -e /petastorm/[test,tf,torch,docs,opencv]
           $RUN pip install --upgrade numpy==$NUMPY_VERSION
           $RUN pip install -U pyarrow==${PYARROW_VERSION} tensorflow==${TF_VERSION} pyspark==${PYSPARK_VERSION}

--- a/petastorm/tests/conftest.py
+++ b/petastorm/tests/conftest.py
@@ -26,7 +26,7 @@ from petastorm.tests.test_common import create_test_dataset, create_test_scalar_
     create_many_columns_non_petastorm_dataset
 from pyspark.sql import SparkSession
 
-SyntheticDataset = namedtuple('synthetic_dataset', ['url', 'data', 'path'])
+SyntheticDataset = namedtuple('SyntheticDataset', ['url', 'data', 'path'])
 
 # Number of rows in a fake dataset
 _ROWS_COUNT = 100

--- a/petastorm/tests/test_generate_metadata.py
+++ b/petastorm/tests/test_generate_metadata.py
@@ -12,7 +12,7 @@ from petastorm.tests.test_common import create_test_dataset, TestSchema
 
 ROWS_COUNT = 1000
 
-SyntheticDataset = namedtuple('synthetic_dataset', ['url', 'data', 'path'])
+SyntheticDataset = namedtuple('SyntheticDataset', ['url', 'data', 'path'])
 
 
 @pytest.fixture(scope="session")

--- a/petastorm/tests/test_ngram_end_to_end.py
+++ b/petastorm/tests/test_ngram_end_to_end.py
@@ -1,4 +1,3 @@
-# pylint: disable=bad-continuation
 # Disabling lint bad-continuation due to lint issues between python 2.7 and python 3.6
 
 #  Copyright (c) 2017-2018 Uber Technologies, Inc.

--- a/petastorm/workers_pool/exec_in_new_process.py
+++ b/petastorm/workers_pool/exec_in_new_process.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         new_process_runnable_file = sys.argv[1]
 
         with open(new_process_runnable_file, 'rb') as f:
-            func, args, kargs = dill.load(f)
+            func, args, kargs = dill.load(f)  # pylint: disable=unpacking-non-sequence
 
         # Don't need the pickle file with the runable. Cleanup.
         os.remove(new_process_runnable_file)

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ EXTRA_REQUIRE = {
         'requests>=2.22.0',
         's3fs>=0.0.1',
         'gcsfs',
+        "types-pytz==2021.1.0",
+        "types-six==0.1.7",
     ],
     'torch': ['torchvision>=0.2.1', 'torch>=1.5.0'],
 }


### PR DESCRIPTION
Renamed config action names to better describe versions in the build.