### PR TITLE
Use pyarrow.ipc.open_stream instead of legacy pyarrow.open_stream

### DIFF
--- a/petastorm/reader_impl/arrow_table_serializer.py
+++ b/petastorm/reader_impl/arrow_table_serializer.py
@@ -28,6 +28,6 @@ class ArrowTableSerializer(object):
         return sink.getvalue()
 
     def deserialize(self, serialized_rows):
-        reader = pa.open_stream(serialized_rows)
+        reader = pa.ipc.open_stream(serialized_rows)
         table = reader.read_all()
         return table


### PR DESCRIPTION
This fixes a warning about usage of a deprecated function.