### PR TITLE
Do not attempt to override pyarrow's dataset.partitions attribute

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [pyspark-2.4, tf-1.15, pyarrow-2.0, latest,  pyarrow-0.17.1, py39]
+        config: [pyspark-2.4, tf-1.15, pyarrow-2.0, pyarrow-4.0, latest,  pyarrow-0.17.1, py39]
         include:
         - config: pyspark-2.4
           PYARROW_VERSION: "2.0.0"
@@ -42,15 +42,22 @@ jobs:
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
           PY: "3.7"
-        - config: pyarrow-2.0
-          PYARROW_VERSION: "2.0.0"
+        - config: pyarrow-3.0
+          PYARROW_VERSION: "3.0.0"
+          NUMPY_VERSION: "1.19.1"
+          TF_VERSION: "2.5.0"
+          PYSPARK_VERSION: "3.0.0"
+          ARROW_PRE_0_15_IPC_FORMAT: 0
+          PY: "3.7"
+        - config: pyarrow-4.0
+          PYARROW_VERSION: "4.0.0"
           NUMPY_VERSION: "1.19.1"
           TF_VERSION: "2.5.0"
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
           PY: "3.7"
         - config: latest
-          PYARROW_VERSION: "3.0.0"
+          PYARROW_VERSION: "5.0.0"
           NUMPY_VERSION: "1.20.1"
           TF_VERSION: "2.5.0"
           PYSPARK_VERSION: "3.0.0"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [pyspark-2.4, tf-1.15, pyarrow-2.0, pyarrow-4.0, latest,  pyarrow-0.17.1, py39]
+        config: [pyspark-2.4, tf-1.15, pyarrow-3.0, pyarrow-4.0, latest,  pyarrow-0.17.1, py39]
         include:
         - config: pyspark-2.4
           PYARROW_VERSION: "2.0.0"

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,6 +13,7 @@ Release 0.11.2 (unreleased)
   `#691 <https://github.com/uber/petastorm/issues/691>`_ ):
   Enable extraction of storage_options from input url.
 - `PR 640 <https://github.com/uber/petastorm/pull/640>`_: Security fix for arbitrary code execution (affects depickling of Unischema loaded from petastorm datasets).
+- `PR 707 <https://github.com/uber/petastorm/pull/707>`_: Fix pyarrow 5.0 compatibility issue: do not override dataset's `partitions` attribute.
 
 
 Release 0.11.1

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -132,7 +132,6 @@ class ArrowReaderWorker(WorkerBase):
                 filesystem=self._filesystem,
                 validate_schema=False, filters=self._arrow_filters)
 
-
         piece = self._split_pieces[piece_index]
 
         # Create pyarrow file system

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -132,10 +132,6 @@ class ArrowReaderWorker(WorkerBase):
                 filesystem=self._filesystem,
                 validate_schema=False, filters=self._arrow_filters)
 
-        if self._dataset.partitions is None:
-            # When read from parquet file list, the `dataset.partitions` will be None.
-            # But other petastorm code require at least an empty `ParquetPartitions` object.
-            self._dataset.partitions = pq.ParquetPartitions()
 
         piece = self._split_pieces[piece_index]
 
@@ -288,7 +284,7 @@ class ArrowReaderWorker(WorkerBase):
         return pa.Table.from_pandas(result, preserve_index=False)
 
     def _read_with_shuffle_row_drop(self, piece, pq_file, column_names, shuffle_row_drop_partition):
-        partition_names = self._dataset.partitions.partition_names
+        partition_names = self._dataset.partitions.partition_names if self._dataset.partitions else set()
 
         # pyarrow would fail if we request a column names that the dataset is partitioned by
         table = piece.read(columns=column_names - partition_names, partitions=self._dataset.partitions)

--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -210,7 +210,8 @@ class PyDictReaderWorker(WorkerBase):
                              'are not valid schema names: ({})'.format(', '.join(invalid_column_names),
                                                                        ', '.join(all_schema_names)))
 
-        other_column_names = all_schema_names - predicate_column_names - self._dataset.partitions.partition_names
+        partition_names = self._dataset.partitions.partition_names if self._dataset.partitions else set()
+        other_column_names = all_schema_names - predicate_column_names - partition_names
 
         # Read columns needed for the predicate
         predicate_rows = self._read_with_shuffle_row_drop(piece, pq_file, predicate_column_names,

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -405,11 +405,6 @@ class Reader(object):
                                          validate_schema=False, metadata_nthreads=10,
                                          filters=filters)
 
-        if self.dataset.partitions is None:
-            # When read from parquet file list, the `dataset.partitions` will be None.
-            # But other petastorm code require at least an empty `ParquetPartitions` object.
-            self.dataset.partitions = pq.ParquetPartitions()
-
         stored_schema = infer_or_load_unischema(self.dataset)
 
         if isinstance(schema_fields, NGram):
@@ -597,8 +592,9 @@ class Reader(object):
                 raise ValueError('predicate parameter is expected to be derived from PredicateBase')
             predicate_fields = predicate.get_fields()
 
-            if set(predicate_fields) == dataset.partitions.partition_names:
-                assert len(dataset.partitions.partition_names) == 1, \
+            partition_names = dataset.partitions.partition_names if dataset.partitions else set()
+            if set(predicate_fields) == partition_names:
+                assert len(partition_names) == 1, \
                     'Datasets with only a single partition level supported at the moment'
 
                 filtered_row_group_indexes = []

--- a/petastorm/unischema.py
+++ b/petastorm/unischema.py
@@ -318,7 +318,7 @@ class Unischema(object):
         arrow_schema = meta.schema.to_arrow_schema()
         unischema_fields = []
 
-        for partition in parquet_dataset.partitions:
+        for partition in (parquet_dataset.partitions or []):
             if (pa.types.is_binary(partition.dictionary.type) and six.PY2) or \
                     (pa.types.is_string(partition.dictionary.type) and six.PY3):
                 numpy_dtype = np.str_


### PR DESCRIPTION
Removing a hack where we manually override pyarrow's `dataset.partitions` property because of an assumption of other parts of code that the attribute is always set and iterable.

pyarrow 5.0 breaks as it protects the attribute against modification.

We fix the issue by explicitly checking for `dataset.partitions` being `None` in relevant parts of petastorm code.

Add a unittest configuration to cover pyarrow 3, 4, and 5.

Resolves #707