### PR TITLE
Fix package versions in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN /petastorm_venv3.7/bin/pip3.7 install --no-cache scikit-build
 RUN /petastorm_venv3.7/bin/pip3.7 install --no-cache -e /petastorm/[test,tf,torch,docs,opencv] --only-binary pyarrow --only-binary opencv-python
 RUN /petastorm_venv3.7/bin/pip3.7 uninstall -y petastorm
 # To avoid some version incompatibilities, we pin these libraries to versions that known to work together
-RUN /petastorm_venv3.7/bin/pip3.7 install -U pyarrow==3.0.0 numpy==1.20.1 tensorflow==2.1.0 pyspark==3.0.0
+RUN /petastorm_venv3.7/bin/pip3.7 install -U pyarrow==3.0.0 numpy==1.19.1 tensorflow==2.1.0 pyspark==3.0.0
 
 # Otherwise we might have trouble with loading of libGL.so.1
 RUN /petastorm_venv3.7/bin/pip3.7 install opencv-python-headless
@@ -58,7 +58,7 @@ RUN /petastorm_venv3.9/bin/pip3.9 install --no-cache scikit-build
 RUN /petastorm_venv3.9/bin/pip3.9 install --no-cache -e /petastorm/[test,tf,torch,docs,opencv] --only-binary pyarrow --only-binary opencv-python
 RUN /petastorm_venv3.9/bin/pip3.9 uninstall -y petastorm
 # To avoid some version incompatibilities, we pin these libraries to versions that known to work together
-RUN /petastorm_venv3.9/bin/pip3.9 install -U pyarrow==3.0.0 numpy==1.20.1 tensorflow==2.5.0 pyspark==3.0.0
+RUN /petastorm_venv3.9/bin/pip3.9 install -U pyarrow==3.0.0 numpy==1.19.3 tensorflow==2.5.0 pyspark==3.0.0
 
 # Otherwise we might have trouble with loading of libGL.so.1
 RUN /petastorm_venv3.9/bin/pip3.9 install opencv-python-headless


### PR DESCRIPTION
Tensorflow2 conflicts with numpy 1.20.1

Error example is:

```
#30 26.12 ERROR: Cannot install numpy==1.20.1, pyarrow==3.0.0 and tensorflow==2.5.0 because these package versions have conflicting dependencies.
#30 26.12
#30 26.12 The conflict is caused by:
#30 26.12     The user requested numpy==1.20.1
#30 26.12     pyarrow 3.0.0 depends on numpy>=1.16.6
#30 26.12     tensorflow 2.5.0 depends on numpy~=1.19.2
#30 26.12
#30 26.12 To fix this you could try to:
#30 26.12 1. loosen the range of package versions you've specified
#30 26.12 2. remove package versions to allow pip attempt to solve the dependency conflict
```