### PR TITLE
fix typo "suffling" -> "shuffling"

### DIFF
--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -160,7 +160,7 @@ class DataLoader(LoaderBase):
         :param batch_size: the number of items to return per batch; factored into the len() of this reader
         :param collate_fn: an optional callable to merge a list of samples to form a mini-batch.
         :param shuffling_queue_capacity: Queue capacity is passed to the underlying :class:`tf.RandomShuffleQueue`
-          instance. If set to 0, no suffling will be done.
+          instance. If set to 0, no shuffling will be done.
         """
         super(DataLoader, self).__init__()
         self.reader = reader

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -269,7 +269,7 @@ class SparkDatasetConverter(object):
             Defaults value ``None``, which means using the default value from
             `petastorm.make_batch_reader()`. We can autotune it in the future.
         :param shuffling_queue_capacity: Queue capacity is passed to the underlying
-            :class:`tf.RandomShuffleQueue` instance. If set to 0, no suffling will be done.
+            :class:`tf.RandomShuffleQueue` instance. If set to 0, no shuffling will be done.
         :param data_loader_fn: A function (or class) that generates a
             `torch.utils.data.DataLoader` object. The default value of ``None`` uses
             `petastorm.pytorch.DataLoader`.
@@ -376,7 +376,7 @@ class TorchDatasetContextManager(object):
             ``None`` value will denotes auto tuned best value for batch size.
         :param petastorm_reader_kwargs: other arguments for petastorm reader
         :param shuffling_queue_capacity: Queue capacity is passed to the underlying
-            :class:`tf.RandomShuffleQueue` instance. If set to 0, no suffling will be done.
+            :class:`tf.RandomShuffleQueue` instance. If set to 0, no shuffling will be done.
         :param data_loader_fn: function to generate the PyTorch DataLoader.
 
         See `SparkDatasetConverter.make_torch_dataloader()`  for the definitions

--- a/petastorm/tf_utils.py
+++ b/petastorm/tf_utils.py
@@ -293,7 +293,7 @@ def tf_tensors(reader, shuffling_queue_capacity=0, min_after_dequeue=0):
 
     :param reader: An instance of petastorm.Reader object used as the data source
     :param shuffling_queue_capacity: Queue capacity is passed to the underlying :class:`tf.RandomShuffleQueue`
-        instance. If set to 0, no suffling will be done.
+        instance. If set to 0, no shuffling will be done.
     :param min_after_dequeue: If ``shuffling_queue_capacity > 0``, this value is passed to the underlying
         :class:`tf.RandomShuffleQueue`.
     :return: If no ngram reading is used, the function will return a named tuple with tensors that are populated


### PR DESCRIPTION
Fixing a typo within code comments