### PR TITLE
Use highest available pickle protocol when serializing

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -10,6 +10,7 @@ Release 0.11.4 (unreleased)
 - `PR 731 <https://github.com/uber/petastorm/pull/731>`_ (resolves `PR 728 <https://github.com/uber/petastorm/issues/728>`_): Support passing multiple parquet dataset urls to make_reader.
 - `PR 732 <https://github.com/uber/petastorm/pull/732>`_ (resolves `PR 585 <https://github.com/uber/petastorm/issues/585>`_): Restructure process_pool implementation code in a way that resolves ``RuntimeWarning: 'petastorm.workers_pool.exec_in_new_process' found in sys.modules after
   import of package 'petastorm.workers_pool', but prior to execution of 'petastorm.workers_pool.exec_in_new_process'; this may result in unpredictable behaviou when using process pool`` warning.
+- `PR 737 <https://github.com/uber/petastorm/pull/737>`_: Use highest available pickle protocol for internal serialization.
 
 
 Release 0.11.3

--- a/petastorm/reader_impl/pickle_serializer.py
+++ b/petastorm/reader_impl/pickle_serializer.py
@@ -17,7 +17,7 @@ import pickle
 class PickleSerializer(object):
 
     def serialize(self, rows):
-        return pickle.dumps(rows)
+        return pickle.dumps(rows, protocol=pickle.HIGHEST_PROTOCOL)
 
     def deserialize(self, serialized_rows):
         return pickle.loads(serialized_rows)


### PR DESCRIPTION
[Pickle protocol 5](https://www.python.org/dev/peps/pep-0574/) allows for zero-copy pickling of numpy arrays, but protocol version 4 remains the default for Python 3.8 onwards. When loading datasets with large numpy arrays and `reader_pool_type="process"`, using protocol 5 significantly improves serialization time and overall performance.

Protocol 5 is only available in Python 3.8 and onwards, so for backwards and forwards compatibility with future pickle protocol improvements we specify `pickle.HIGHEST_PROTOCOL`.

## Small test case
```
import time
import numpy as np
from petastorm.reader_impl.pickle_serializer import PickleSerializer

s = PickleSerializer()
data = [np.random.random((1000, 1000)) for _ in range(10)]
t = time.time()
for x in range(100):
  _ = s.deserialize(s.serialize(data))
print(time.time() - t)
```
master:
11.40 sec

This PR:
8.78 sec