### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility

### DIFF
--- a/petastorm/predicates.py
+++ b/petastorm/predicates.py
@@ -16,7 +16,7 @@
 Predicates for petastorm
 """
 import abc
-import collections
+import collections.abc
 import hashlib
 import numpy as np
 import six
@@ -66,7 +66,7 @@ class in_intersection(PredicateBase):
         return {self._predicate_field}
 
     def do_include(self, values):
-        if not isinstance(values[self._predicate_field], collections.Iterable):
+        if not isinstance(values[self._predicate_field], collections.abc.Iterable):
             raise ValueError('Predicate field should have iterable type')
         return any(np.in1d(values[self._predicate_field], self._inclusion_values))
 

--- a/petastorm/pytorch.py
+++ b/petastorm/pytorch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
 import decimal
 # Must import pyarrow before torch. See: https://github.com/uber/petastorm/blob/master/docs/troubleshoot.rst
 import re
@@ -84,11 +84,11 @@ def decimal_friendly_collate(batch):
 
     if isinstance(batch[0], decimal.Decimal):
         return batch
-    elif isinstance(batch[0], collections.Mapping):
+    elif isinstance(batch[0], collections.abc.Mapping):
         return {key: decimal_friendly_collate([d[key] for d in batch]) for key in batch[0]}
     elif isinstance(batch[0], _string_classes):
         return batch
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], collections.abc.Sequence):
         transposed = zip(*batch)
         return [decimal_friendly_collate(samples) for samples in transposed]
     else:

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
 import logging
 import warnings
 
@@ -395,7 +395,7 @@ class Reader(object):
         #    c. partition: used to get a subset of data for distributed training
         # 4. Create a rowgroup ventilator object
         # 5. Start workers pool
-        if not (isinstance(schema_fields, collections.Iterable) or isinstance(schema_fields, NGram)
+        if not (isinstance(schema_fields, collections.abc.Iterable) or isinstance(schema_fields, NGram)
                 or schema_fields is None):
             raise ValueError('Fields must be either None, an iterable collection of Unischema fields '
                              'or an NGram object.')
@@ -431,7 +431,7 @@ class Reader(object):
         if self.ngram:
             fields = self.ngram.get_field_names_at_all_timesteps()
         else:
-            fields = schema_fields if isinstance(schema_fields, collections.Iterable) else None
+            fields = schema_fields if isinstance(schema_fields, collections.abc.Iterable) else None
 
         storage_schema = stored_schema.create_schema_view(fields) if fields else stored_schema
         if len(storage_schema.fields) == 0:


### PR DESCRIPTION
Import ABC from `collections` was deprecated and removed in Python 3.10. Use `collections.abc` .