### PR TITLE
Wrapper for Arrow Datasets & Dataset Pieces

### DIFF
--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -19,10 +19,10 @@ import operator
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from pyarrow import parquet as pq
 from pyarrow.parquet import ParquetFile
 
 from petastorm.cache import NullCache
+from petastorm.pyarrow_helpers.dataset_wrapper import PetastormPyArrowDataset
 from petastorm.workers_pool import EmptyResultError
 from petastorm.workers_pool.worker_base import WorkerBase
 
@@ -127,7 +127,7 @@ class ArrowReaderWorker(WorkerBase):
         """
 
         if not self._dataset:
-            self._dataset = pq.ParquetDataset(
+            self._dataset = PetastormPyArrowDataset(
                 self._dataset_path_or_paths,
                 filesystem=self._filesystem,
                 validate_schema=False, filters=self._arrow_filters)

--- a/petastorm/etl/metadata_util.py
+++ b/petastorm/etl/metadata_util.py
@@ -16,10 +16,10 @@
 from __future__ import print_function
 
 import argparse
-from pyarrow import parquet as pq
 
 from petastorm.etl import dataset_metadata, rowgroup_indexing
 from petastorm.fs_utils import FilesystemResolver
+from petastorm.pyarrow_helpers.dataset_wrapper import PetastormPyArrowDataset
 
 if __name__ == "__main__":
 
@@ -47,8 +47,8 @@ if __name__ == "__main__":
 
     # Create pyarrow file system
     resolver = FilesystemResolver(args.dataset_url, hdfs_driver=args.hdfs_driver)
-    dataset = pq.ParquetDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
-                                validate_schema=False)
+    dataset = PetastormPyArrowDataset(resolver.get_dataset_path(), filesystem=resolver.filesystem(),
+                                      validate_schema=False)
 
     print_all = not args.schema and not args.index
     if args.schema or print_all:

--- a/petastorm/etl/petastorm_generate_metadata.py
+++ b/petastorm/etl/petastorm_generate_metadata.py
@@ -18,12 +18,12 @@ import argparse
 import sys
 from pydoc import locate
 
-from pyarrow import parquet as pq
 from pyspark.sql import SparkSession
 
 from petastorm.etl.dataset_metadata import materialize_dataset, get_schema, ROW_GROUPS_PER_FILE_KEY
 from petastorm.etl.rowgroup_indexing import ROWGROUPS_INDEX_KEY
 from petastorm.fs_utils import FilesystemResolver
+from petastorm.pyarrow_helpers.dataset_wrapper import PetastormPyArrowDataset
 from petastorm.unischema import Unischema
 from petastorm.utils import add_to_dataset_metadata
 
@@ -63,7 +63,7 @@ def generate_petastorm_metadata(spark, dataset_url, unischema_class=None, use_su
     resolver = FilesystemResolver(dataset_url, sc._jsc.hadoopConfiguration(), hdfs_driver=hdfs_driver,
                                   user=spark.sparkContext.sparkUser())
     fs = resolver.filesystem()
-    dataset = pq.ParquetDataset(
+    dataset = PetastormPyArrowDataset(
         resolver.get_dataset_path(),
         filesystem=fs,
         validate_schema=False)

--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -18,11 +18,11 @@ import threading
 from collections.abc import Iterable
 
 import numpy as np
-from pyarrow import parquet as pq
 from pyarrow.parquet import ParquetFile
 
 from petastorm import utils
 from petastorm.cache import NullCache
+from petastorm.pyarrow_helpers.dataset_wrapper import PetastormPyArrowDataset
 from petastorm.workers_pool import EmptyResultError
 from petastorm.workers_pool.worker_base import WorkerBase
 
@@ -133,7 +133,7 @@ class PyDictReaderWorker(WorkerBase):
         """
 
         if not self._dataset:
-            self._dataset = pq.ParquetDataset(
+            self._dataset = PetastormPyArrowDataset(
                 self._dataset_path,
                 filesystem=self._filesystem,
                 validate_schema=False, filters=self._arrow_filters)

--- a/petastorm/pyarrow_helpers/dataset_wrapper.py
+++ b/petastorm/pyarrow_helpers/dataset_wrapper.py
@@ -1,0 +1,98 @@
+#  Copyright (c) 2022 BlackBerry Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyarrow import parquet as pq
+
+
+class PetastormPyArrowDataset:
+
+    def __init__(self, path_or_paths, filesystem=None, validate_schema=None, filters=None, metadata_nthreads=None,
+                 use_new_arrow_api=False):
+        if use_new_arrow_api:
+            raise NotImplementedError("The implementation using the new PyArrow API is not yet complete")
+
+        kwargs = {}
+        if filesystem:
+            kwargs["filesystem"] = filesystem
+        if validate_schema is not None:
+            kwargs["validate_schema"] = validate_schema
+        if filters:
+            kwargs["filters"] = filters
+        if metadata_nthreads:
+            kwargs["metadata_nthreads"] = metadata_nthreads
+
+        self._legacy_dataset = pq.ParquetDataset(path_or_paths, **kwargs)
+
+    @property
+    def common_metadata(self):
+        return self._legacy_dataset.common_metadata
+
+    @property
+    def metadata(self):
+        return self._legacy_dataset.metadata
+
+    @property
+    def metadata_path(self):
+        return self._legacy_dataset.metadata_path
+
+    @property
+    def fs(self):
+        return self._legacy_dataset.fs
+
+    @property
+    def partitions(self):
+        return self._legacy_dataset.partitions
+
+    @property
+    def paths(self):
+        return self._legacy_dataset.paths
+
+    @property
+    def pieces(self):
+        if not hasattr(self, "_wrapped_pieces"):
+            self._wrapped_pieces = [_wrap_piece(piece) for piece in self._legacy_dataset.pieces]
+        return self._wrapped_pieces
+
+
+def _wrap_piece(piece):
+    return PetastormPyArrowDatasetPiece(piece.path, open_file_func=piece.open_file_func, row_group=piece.row_group,
+                                        partition_keys=piece.partition_keys)
+
+
+class PetastormPyArrowDatasetPiece:
+
+    def __init__(self, path, open_file_func, row_group, partition_keys, use_new_arrow_api=False):
+        if use_new_arrow_api:
+            raise NotImplementedError("The implementation using the new PyArrow API is not yet complete")
+
+        self._legacy_piece = pq.ParquetDatasetPiece(path, open_file_func=open_file_func, row_group=row_group,
+                                                    partition_keys=partition_keys)
+
+    def get_metadata(self):
+        return self._legacy_piece.get_metadata()
+
+    def read(self, *, columns, partitions):
+        return self._legacy_piece.read(columns=columns, partitions=partitions)
+
+    @property
+    def path(self):
+        return self._legacy_piece.path
+
+    @property
+    def partition_keys(self):
+        return self._legacy_piece.partition_keys
+
+    @property
+    def row_group(self):
+        return self._legacy_piece.row_group

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -17,7 +17,6 @@ import logging
 import warnings
 
 import six
-from pyarrow import parquet as pq
 
 from petastorm.arrow_reader_worker import ArrowReaderWorker
 from petastorm.cache import NullCache
@@ -30,6 +29,7 @@ from petastorm.local_disk_cache import LocalDiskCache
 from petastorm.ngram import NGram
 from petastorm.predicates import PredicateBase
 from petastorm.py_dict_reader_worker import PyDictReaderWorker
+from petastorm.pyarrow_helpers.dataset_wrapper import PetastormPyArrowDataset
 from petastorm.reader_impl.arrow_table_serializer import ArrowTableSerializer
 from petastorm.reader_impl.pickle_serializer import PickleSerializer
 from petastorm.selectors import RowGroupSelectorBase
@@ -402,9 +402,9 @@ class Reader(object):
 
         self.is_batched_reader = is_batched_reader
         # 1. Resolve dataset path (hdfs://, file://) and open the parquet storage (dataset)
-        self.dataset = pq.ParquetDataset(dataset_path, filesystem=pyarrow_filesystem,
-                                         validate_schema=False, metadata_nthreads=10,
-                                         filters=filters)
+        self.dataset = PetastormPyArrowDataset(dataset_path, filesystem=pyarrow_filesystem,
+                                               validate_schema=False, metadata_nthreads=10,
+                                               filters=filters)
 
         stored_schema = infer_or_load_unischema(self.dataset)
 


### PR DESCRIPTION
This is a wrapper around PyArrow's ParquetDataset and ParquetDatasetPieces, the first part of the effort to support PyArrow's new Dataset API that was [discussed in issue #613](https://github.com/uber/petastorm/issues/613#issuecomment-1086425134).

Since this wrapper has no functionality of its own, I didn't add unit tests specifically for the wrapper; let me know if I should.

I was unable to get the tests in `petastorm/tests/test_tf_dataset.py` to complete when running them inside the provided docker container, even when I left them to run for over 24 hours. Given that this is only a wrapper, and the code paths where the wrapper is used are covered by other tests, I think it's unlikely that tests in that file would fail when all other tests pass, but I'll keep an eye on the CI results. If they fail, then don't bother reviewing this until I fix them up (which may take several rounds of pushing new commits, as I can only run those tests in CI and not locally).