### PR TITLE
Replace process_iter by pid_exists

### DIFF
--- a/petastorm/workers_pool/process_pool.py
+++ b/petastorm/workers_pool/process_pool.py
@@ -23,7 +23,7 @@ from time import sleep, time
 from traceback import format_exc
 
 from threading import Thread
-from psutil import process_iter
+from psutil import pid_exists
 
 import zmq
 from zmq import ZMQBaseError
@@ -320,7 +320,7 @@ def _serialize_result_and_send(socket, serializer, data):
 def _monitor_thread_function(main_process_pid):
     while True:
         logger.debug('Monitor thread monitoring pid: %d', main_process_pid)
-        main_process_alive = any([process.pid for process in process_iter() if process.pid == main_process_pid])
+        main_process_alive = pid_exists(main_process_pid)
         if not main_process_alive:
             logger.debug('Main process with pid %d is dead. Killing worker', main_process_pid)
             os._exit(0)

--- a/petastorm/workers_pool/tests/test_workers_pool.py
+++ b/petastorm/workers_pool/tests/test_workers_pool.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 from multiprocessing import Process, Manager
-from psutil import process_iter
+from psutil import pid_exists
 
 
 from petastorm.workers_pool import EmptyResultError
@@ -242,7 +242,7 @@ class TestWorkersPool(unittest.TestCase):
         worker_pid = return_list[0]
 
         for _ in range(20):
-            worker_is_alive = any([p.pid for p in process_iter() if p.pid == worker_pid])
+            worker_is_alive = pid_exists(worker_pid)
             if not worker_is_alive:
                 break
             time.sleep(0.1)


### PR DESCRIPTION
`process_iter` is very slow for checking if a process is alive. `pid_exists` is more efficient.

See: https://psutil.readthedocs.io/en/latest/index.html?highlight=process_iter#psutil.pid_exists
