### PR TITLE
PyTorch: improve memory-efficiency in batched non-shuffle buffer

### DIFF
--- a/petastorm/tests/test_shuffling_buffer.py
+++ b/petastorm/tests/test_shuffling_buffer.py
@@ -47,9 +47,11 @@ def test_noop_shuffling_buffer(buffer_type):
     assert 2 == _retrieve(q)
     assert 3 == _retrieve(q)
     assert not q.can_retrieve()
+    assert q.size == 0
 
-    # No effect is expected in noop implementation
     q.finish()
+    if isinstance(q, BatchedNoopShufflingBuffer):
+        assert q._done_adding
 
 
 def _add_many(q, lst):


### PR DESCRIPTION
Avoid creating many copies in _make_batch().

Fix #763 