### PR TITLE
upgrade readthedocs to use Py3.7

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -26,7 +26,7 @@ formats: []
 #  - epub
 
 python:
-  version: 3.6
+  version: 3.7
   setup_py_install: true
   # Use PIP install ONLY if there are extra requirements below
   pip_install: false


### PR DESCRIPTION
Readthedocs build hit failure when using Python 3.6 with latest PyArrow.