### PR TITLE
Reader: enable shuffling inside every row group

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,23 @@ Release notes
 
 Release 0.11.6 (unreleased)
 ===========================
+- `PR 767 <https://github.com/uber/petastorm/pull/767>`_: Reader: enable shuffling inside every row group.
+
+New features
+--------------------------
+- Parallel shuffling is implemented in reader level to increase throughput.
+
+  - Introduce ``shuffle_rows`` boolean field in ``Reader``, ``make_reader()`` and ``make_batch_reader()``
+    to enable shuffling inside a single row group.
+
+  - Break the bottleneck of shuffling samples in upper level PyTorch or Tensorflow dataloaders.
+
+- Support reproducible randomized shuffling outputs with ``seed`` field in ``Reader``, ``make_reader()`` and ``make_batch_reader()``.
+
+Deprecated features
+--------------------------
+- ``shard_seed`` field is deprecated in ``Reader``, ``make_reader()`` and ``make_batch_reader()``,
+  use ``seed`` field to apply randomization effects on sharding row groups.
 
 
 Release 0.11.5

--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -109,6 +109,8 @@ class PyDictReaderWorker(WorkerBase):
         self._local_cache = args[5]
         self._transform_spec = args[6]
         self._arrow_filters = args[8]
+        self._shuffle_rows = args[9]
+        self._shuffle_seed = args[10]
 
         # We create datasets lazily in the first invocation of 'def process'. This speeds up startup time since
         # all Worker constructors are serialized
@@ -264,6 +266,8 @@ class PyDictReaderWorker(WorkerBase):
         # with nulls translated to nans
         data_frame = piece.read(columns=column_names, partitions=self._dataset.partitions).to_pandas(
             integer_object_nulls=True)
+        if self._shuffle_rows:
+            data_frame = data_frame.sample(frac=1, random_state=self._shuffle_seed)
 
         num_rows = len(data_frame)
         num_partitions = shuffle_row_drop_partition[1]

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -61,6 +61,7 @@ def normalize_dataset_url_or_urls(dataset_url_or_urls):
 def make_reader(dataset_url,
                 schema_fields=None,
                 reader_pool_type='thread', workers_count=10, pyarrow_serialize=False, results_queue_size=50,
+                seed=None, shuffle_rows=False,
                 shuffle_row_groups=True, shuffle_row_drop_partitions=1,
                 predicate=None,
                 rowgroup_selector=None,
@@ -95,6 +96,8 @@ def make_reader(dataset_url,
     :param pyarrow_serialize: THE ARGUMENT IS DEPRECATED AND WILL BE REMOVED IN FUTURE VERSIONS.
     :param results_queue_size: Size of the results queue to store prefetched row-groups. Currently only applicable to
         thread reader pool type.
+    :param seed: Random seed specified for shuffle and sharding with reproducible outputs. Defaults to None
+    :param shuffle_rows: Whether to shuffle inside a single row group. Defaults to False.
     :param shuffle_row_groups: Whether to shuffle row groups (the order in which full row groups are read)
     :param shuffle_row_drop_partitions: This is is a positive integer which determines how many partitions to
         break up a row group into for increased shuffling in exchange for worse performance (extra reads).
@@ -110,7 +113,7 @@ def make_reader(dataset_url,
         pass in a unique shard number in the range [0, shard_count). shard_count must be supplied as well.
         Defaults to None
     :param shard_count: An int denoting the number of shards to break this dataset into. Defaults to None
-    :param shard_seed: Random seed to shuffle row groups for data sharding. Defaults to None
+    :param shard_seed: (Deprecated) Random seed used for sharding row groups. Defaults to None
     :param cache_type: A string denoting the cache type, if desired. Options are [None, 'null', 'local-disk'] to
         either have a null/noop cache or a cache implemented using diskcache. Caching is useful when communication
         to the main data store is either slow or expensive and the local machine has large enough storage
@@ -172,6 +175,8 @@ def make_reader(dataset_url,
     kwargs = {
         'schema_fields': schema_fields,
         'reader_pool': reader_pool,
+        'shuffle_rows': shuffle_rows,
+        'seed': seed,
         'shuffle_row_groups': shuffle_row_groups,
         'shuffle_row_drop_partitions': shuffle_row_drop_partitions,
         'predicate': predicate,
@@ -201,6 +206,7 @@ def make_reader(dataset_url,
 def make_batch_reader(dataset_url_or_urls,
                       schema_fields=None,
                       reader_pool_type='thread', workers_count=10,
+                      seed=None, shuffle_rows=False,
                       shuffle_row_groups=True, shuffle_row_drop_partitions=1,
                       predicate=None,
                       rowgroup_selector=None,
@@ -238,6 +244,8 @@ def make_batch_reader(dataset_url_or_urls,
         denoting a thread pool, process pool, or running everything in the master thread. Defaults to 'thread'
     :param workers_count: An int for the number of workers to use in the reader pool. This only is used for the
         thread or process pool. Defaults to 10
+    :param seed: Random seed specified for shuffle and sharding with reproducible outputs. Defaults to None
+    :param shuffle_rows: Whether to shuffle inside a single row group. Defaults to False.
     :param shuffle_row_groups: Whether to shuffle row groups (the order in which full row groups are read)
     :param shuffle_row_drop_partitions: This is is a positive integer which determines how many partitions to
         break up a row group into for increased shuffling in exchange for worse performance (extra reads).
@@ -254,7 +262,7 @@ def make_batch_reader(dataset_url_or_urls,
         pass in a unique shard number in the range [0, shard_count). shard_count must be supplied as well.
         Defaults to None
     :param shard_count: An int denoting the number of shards to break this dataset into. Defaults to None
-    :param shard_seed: Random seed to shuffle row groups for data sharding. Defaults to None
+    :param shard_seed: (Deprecated) Random seed used for sharding row groups. Defaults to None
     :param cache_type: A string denoting the cache type, if desired. Options are [None, 'null', 'local-disk'] to
         either have a null/noop cache or a cache implemented using diskcache. Caching is useful when communication
         to the main data store is either slow or expensive and the local machine has large enough storage
@@ -318,6 +326,8 @@ def make_batch_reader(dataset_url_or_urls,
                   schema_fields=schema_fields,
                   worker_class=ArrowReaderWorker,
                   reader_pool=reader_pool,
+                  seed=seed,
+                  shuffle_rows=shuffle_rows,
                   shuffle_row_groups=shuffle_row_groups,
                   shuffle_row_drop_partitions=shuffle_row_drop_partitions,
                   predicate=predicate,
@@ -339,7 +349,8 @@ class Reader(object):
     """
 
     def __init__(self, pyarrow_filesystem, dataset_path, schema_fields=None,
-                 shuffle_row_groups=True, shuffle_row_drop_partitions=1,
+                 seed=None, shuffle_rows=False, shuffle_row_groups=True,
+                 shuffle_row_drop_partitions=1,
                  predicate=None, rowgroup_selector=None, reader_pool=None, num_epochs=1,
                  cur_shard=None, shard_count=None, cache=None, worker_class=None,
                  transform_spec=None, is_batched_reader=False, filters=None, shard_seed=None):
@@ -355,6 +366,8 @@ class Reader(object):
             or ``[/tmp/mydataset/00000.parquet, /tmp/mydataset/00001.parquet]``
         :param schema_fields: Either list of unischema fields to subset, or ``None`` to read all fields.
             OR an NGram object, then it will return an NGram of the specified properties.
+        :param seed: Random seed specified for shuffle and sharding with reproducible outputs. Defaults to None
+        :param shuffle_rows: Whether to shuffle inside a single row group. Defaults to False.
         :param shuffle_row_groups: Whether to shuffle row groups (the order in which full row groups are read)
         :param shuffle_row_drop_partitions: This is is a positive integer which determines how many partitions to
             break up a row group into for increased shuffling in exchange for worse performance (extra reads).
@@ -373,6 +386,7 @@ class Reader(object):
             pass in a unique shard number in the range ``[0, shard_count)``.
             ``shard_count`` must be supplied as well. Defaults to None
         :param shard_count: An int denoting the number of shard partitions there are. Defaults to None
+        :param shard_seed: (Deprecated) Random seed used for sharding row groups. Defaults to None
         :param cache: An object conforming to :class:`.CacheBase` interface. Before loading row groups from a parquet
             file the Reader will attempt to load these values from cache. Caching is useful when communication
             to the main data store is either slow or expensive and the local machine has large enough storage
@@ -383,7 +397,6 @@ class Reader(object):
         :param filters: (List[Tuple] or List[List[Tuple]]): Standard PyArrow filters.
             These will be applied when loading the parquet file with PyArrow. More information
             here: https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html
-        :param shard_seed: Random seed to shuffle row groups for data sharding. Defaults to None
         """
         self.num_epochs = num_epochs
 
@@ -445,21 +458,28 @@ class Reader(object):
         row_groups = dataset_metadata.load_row_groups(self.dataset)
 
         # 3. Filter rowgroups
+        _shard_seed = seed
+        if shard_seed:
+            warnings.warn("shard_seed was deprecated and will be removed in future versions. "
+                          "Use seed to apply randomization effects on sharding row groups.")
+            # Use shard_seed to overwrite, to be removed in future.
+            _shard_seed = shard_seed
         filtered_row_group_indexes, worker_predicate = self._filter_row_groups(self.dataset, row_groups, predicate,
                                                                                rowgroup_selector, cur_shard,
-                                                                               shard_count, shard_seed)
+                                                                               shard_count, _shard_seed)
         # 4. Create a rowgroup ventilator object
         normalized_shuffle_row_drop_partitions = \
             self._normalize_shuffle_options(shuffle_row_drop_partitions, self.dataset)
         self.ventilator = self._create_ventilator(filtered_row_group_indexes, shuffle_row_groups,
                                                   normalized_shuffle_row_drop_partitions,
                                                   self.num_epochs, worker_predicate,
-                                                  self._workers_pool.workers_count + _VENTILATE_EXTRA_ROWGROUPS)
+                                                  self._workers_pool.workers_count + _VENTILATE_EXTRA_ROWGROUPS,
+                                                  seed)
 
         # 5. Start workers pool
         self._workers_pool.start(worker_class, (pyarrow_filesystem, dataset_path, storage_schema,
                                                 self.ngram, row_groups, cache, transform_spec,
-                                                self.schema, filters),
+                                                self.schema, filters, shuffle_rows, seed),
                                  ventilator=self.ventilator)
         logger.debug('Workers pool started')
 
@@ -497,7 +517,7 @@ class Reader(object):
         return self._results_queue_reader.batched_output
 
     def _filter_row_groups(self, dataset, row_groups, predicate, rowgroup_selector, cur_shard,
-                           shard_count, shard_seed):
+                           shard_count, seed):
         """Calculates which rowgroups will be read during.
 
         The following filters are applied:
@@ -511,8 +531,8 @@ class Reader(object):
         :param rowgroup_selector: instance of row group selector object to select row groups to be read
         :param cur_shard: An int denoting the current shard number used. Each node should
                        pass in a unique partition number in the range [0, shard_count).
-        :param shard_count An int denoting the number of reader shards
-        :param shard_seed: If not None: random seed to shuffle row groups for data sharding.
+        :param shard_count: An int denoting the number of reader shards
+        :param seed: If not None: random seed to shuffle row groups for data sharding.
         :return: (filtered_row_group_indexes, worker_predicate): filtered_row_group_indexes an integer index into
         row_groups array. worker_predicate contains only predicates that could not be resolved on the partitioned fields
         and need to be evaluated by workers.
@@ -528,7 +548,7 @@ class Reader(object):
         if cur_shard is not None or shard_count is not None:
             filtered_row_group_indexes = self._partition_row_groups(dataset, row_groups, shard_count,
                                                                     cur_shard,
-                                                                    filtered_row_group_indexes, shard_seed)
+                                                                    filtered_row_group_indexes, seed)
 
         if not filtered_row_group_indexes:
             warnings.warn('No matching data is available for loading after rowgroup '
@@ -537,7 +557,7 @@ class Reader(object):
         return filtered_row_group_indexes, worker_predicate
 
     def _partition_row_groups(self, dataset, row_groups, shard_count, cur_shard,
-                              filtered_row_group_indexes, shard_seed):
+                              filtered_row_group_indexes, seed):
         """Filters the list of row group indexes based on the requested training partitions. Returns
         a modified list of rowgroup indexes."""
 
@@ -552,11 +572,11 @@ class Reader(object):
 
         # We hash on the relative path of each parquet file to guarantee consistency between different reader
         # constructions even after moving the dataset
-        if shard_seed is not None:
+        if seed is not None:
             import random
             # Instantiate a new Random class with a seed and sample from it.
             # Avoid affecting global/default random generator.
-            shard_random = random.Random(shard_seed)
+            shard_random = random.Random(seed)
             shard_random.shuffle(filtered_row_group_indexes)
 
         filtered_row_group_indexes = [index for index in filtered_row_group_indexes if index % shard_count == cur_shard]
@@ -630,7 +650,7 @@ class Reader(object):
         return shuffle_row_drop_partitions
 
     def _create_ventilator(self, row_group_indexes, shuffle_row_groups, shuffle_row_drop_partitions,
-                           num_epochs, worker_predicate, max_ventilation_queue_size):
+                           num_epochs, worker_predicate, max_ventilation_queue_size, seed):
         items_to_ventilate = []
         for piece_index in row_group_indexes:
             for shuffle_row_drop_partition in range(shuffle_row_drop_partitions):
@@ -644,7 +664,8 @@ class Reader(object):
                                     items_to_ventilate,
                                     iterations=num_epochs,
                                     max_ventilation_queue_size=max_ventilation_queue_size,
-                                    randomize_item_order=shuffle_row_groups)
+                                    randomize_item_order=shuffle_row_groups,
+                                    random_seed=seed)
 
     def stop(self):
         """Stops all worker threads/processes."""

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -457,11 +457,11 @@ def test_predicate_with_invalid_fields(synthetic_dataset, reader_factory):
 
 
 @pytest.mark.parametrize('reader_factory', MINIMAL_READER_FLAVOR_FACTORIES + SCALAR_ONLY_READER_FACTORIES)
-@pytest.mark.parametrize('shard_seed', [None, 0])
-def test_partition_multi_node(synthetic_dataset, reader_factory, shard_seed):
+@pytest.mark.parametrize('seed', [None, 0])
+def test_partition_multi_node(synthetic_dataset, reader_factory, seed):
     """Tests that the reader only returns half of the expected data consistently"""
-    with reader_factory(synthetic_dataset.url, cur_shard=0, shard_count=5, shard_seed=shard_seed) as reader:
-        with reader_factory(synthetic_dataset.url, cur_shard=0, shard_count=5, shard_seed=shard_seed) as reader_2:
+    with reader_factory(synthetic_dataset.url, cur_shard=0, shard_count=5, seed=seed) as reader:
+        with reader_factory(synthetic_dataset.url, cur_shard=0, shard_count=5, seed=seed) as reader_2:
             results_1 = set(_readout_all_ids(reader))
             results_2 = set(_readout_all_ids(reader_2))
 
@@ -474,7 +474,7 @@ def test_partition_multi_node(synthetic_dataset, reader_factory, shard_seed):
             # Test that separate partitions also have no overlap by checking ids)
             for partition in range(1, 5):
                 with reader_factory(synthetic_dataset.url, cur_shard=partition,
-                                    shard_count=5, shard_seed=shard_seed) as reader_other:
+                                    shard_count=5, seed=seed) as reader_other:
                     ids_in_other_partition = set(_readout_all_ids(reader_other))
 
                     assert not ids_in_other_partition.intersection(results_1)

--- a/petastorm/tests/test_reader.py
+++ b/petastorm/tests/test_reader.py
@@ -87,3 +87,10 @@ def test_invalid_cache_type(synthetic_dataset, reader_factory):
 def test_invalid_reader_pool_type(synthetic_dataset, reader_factory):
     with pytest.raises(ValueError, match='Unknown reader_pool_type'):
         reader_factory(synthetic_dataset.url, reader_pool_type='bogus_pool_type')
+
+
+@pytest.mark.parametrize('reader_factory', READER_FACTORIES)
+def test_deprecated_shard_seed(synthetic_dataset, reader_factory):
+    match_str = 'shard_seed was deprecated and will be removed in future versions.'
+    with pytest.warns(UserWarning, match=match_str):
+        reader_factory(synthetic_dataset.url, shard_seed=123)

--- a/petastorm/workers_pool/ventilator.py
+++ b/petastorm/workers_pool/ventilator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
+import numpy as np
 import threading
 from abc import ABCMeta, abstractmethod
 from time import sleep
@@ -66,6 +66,7 @@ class ConcurrentVentilator(Ventilator):
                  items_to_ventilate,
                  iterations=1,
                  randomize_item_order=False,
+                 random_seed=None,
                  max_ventilation_queue_size=None,
                  ventilation_interval=_VENTILATION_INTERVAL):
         """
@@ -79,6 +80,7 @@ class ConcurrentVentilator(Ventilator):
                 ``None`` is passed, the ventilator will continue ventilating forever.
         :param randomize_item_order: (``bool``) Whether to randomize the item order in items_to_ventilate. This will be
                 done on every individual iteration.
+        :param random_seed: (``int``) If not None: the random seed used for randomize_item_order. Default: None.
         :param max_ventilation_queue_size: (``int``) The maximum number of items to be stored in the ventilation queue.
                 The higher this number, the higher potential memory requirements. By default it will use the size
                 of items_to_ventilate since that can definitely be held in memory.
@@ -96,7 +98,7 @@ class ConcurrentVentilator(Ventilator):
         self._items_to_ventilate = items_to_ventilate
         self._iterations_remaining = iterations
         self._randomize_item_order = randomize_item_order
-
+        self._random_state = np.random.RandomState(seed=random_seed)
         self._iterations = iterations
 
         # For the default max ventilation queue size we will use the size of the items to ventilate
@@ -141,7 +143,7 @@ class ConcurrentVentilator(Ventilator):
 
             # If we are ventilating the first item, we check if we would like to randomize the item order
             if self._current_item_to_ventilate == 0 and self._randomize_item_order:
-                random.shuffle(self._items_to_ventilate)
+                self._random_state.shuffle(self._items_to_ventilate)
 
             # Block until queue has room, but use continue to allow for checking if stop has been called
             if self._ventilated_items_count - self._processed_items_count >= self._max_ventilation_queue_size:


### PR DESCRIPTION
- Allow shuffle inside every single row group in reader.
- Also use a shuffle seed to generate reproducible shuffle results across: single row shuffle, row groups shuffle in ventilator and sharding.