### PR TITLE
Add a collate_lists_fn

### DIFF
--- a/petastorm/py_dict_reader_worker.py
+++ b/petastorm/py_dict_reader_worker.py
@@ -16,6 +16,7 @@ from __future__ import division
 import hashlib
 import threading
 from collections.abc import Iterable
+from typing import Callable
 
 import numpy as np
 from pyarrow import parquet as pq
@@ -117,7 +118,9 @@ class PyDictReaderWorker(WorkerBase):
         self._dataset = None
 
     @staticmethod
-    def new_results_queue_reader():
+    def new_results_queue_reader(collate_lists_fn: Callable):
+        if collate_lists_fn is not None:
+            raise "PyDictReaderWorker can not collate records"
         return PyDictReaderWorkerResultsQueueReader()
 
     # pylint: disable=arguments-differ

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -194,6 +194,7 @@ def make_reader(dataset_url,
         return Reader(filesystem, dataset_path,
                       worker_class=PyDictReaderWorker,
                       is_batched_reader=False,
+                      collate_lists_fn=None,
                       **kwargs)
     except PetastormMetadataError as e:
         logger.error('Unexpected exception: %s', str(e))
@@ -219,7 +220,8 @@ def make_batch_reader(dataset_url_or_urls,
                       filters=None,
                       storage_options=None,
                       zmq_copy_buffers=True,
-                      filesystem=None):
+                      filesystem=None,
+                      collate_lists_fn=None):
     """
     Creates an instance of Reader for reading batches out of a non-Petastorm Parquet store.
 
@@ -339,7 +341,8 @@ def make_batch_reader(dataset_url_or_urls,
                   cache=cache,
                   transform_spec=transform_spec,
                   is_batched_reader=True,
-                  filters=filters)
+                  filters=filters,
+                  collate_lists_fn=collate_lists_fn)
 
 
 class Reader(object):
@@ -353,7 +356,8 @@ class Reader(object):
                  shuffle_row_drop_partitions=1,
                  predicate=None, rowgroup_selector=None, reader_pool=None, num_epochs=1,
                  cur_shard=None, shard_count=None, cache=None, worker_class=None,
-                 transform_spec=None, is_batched_reader=False, filters=None, shard_seed=None):
+                 transform_spec=None, is_batched_reader=False, filters=None, shard_seed=None,
+                 collate_lists_fn=None):
         """Initializes a reader object.
 
         :param pyarrow_filesystem: An instance of ``pyarrow.FileSystem`` that will be used. If not specified,
@@ -429,7 +433,7 @@ class Reader(object):
 
         # By default, use original method of working with list of dictionaries and not arrow tables
         worker_class = worker_class or PyDictReaderWorker
-        self._results_queue_reader = worker_class.new_results_queue_reader()
+        self._results_queue_reader = worker_class.new_results_queue_reader(collate_lists_fn)
 
         if self.ngram and not self.ngram.timestamp_overlap and shuffle_row_drop_partitions > 1:
             raise NotImplementedError('Using timestamp_overlap=False is not implemented with'


### PR DESCRIPTION
The function allows user to specify their own lists collate logic.
Before the change we would always raise an error if length of lists in a single batch would not be the same (when using make_batch_reader)