### PR TITLE
Update CI to use latest versions of pyarrow and numpy. Drop pyarrow 4 test config.

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [pyspark-2.4, tf-1.15, pyarrow-3.0, pyarrow-4.0, latest]
+        config: [pyspark-2.4, tf-1.15, pyarrow-3.0, latest]
         include:
         - config: pyspark-2.4
           PYARROW_VERSION: "2.0.0"
@@ -47,18 +47,11 @@ jobs:
           PYSPARK_VERSION: "3.0.0"
           ARROW_PRE_0_15_IPC_FORMAT: 0
           PY: "3.7"
-        - config: pyarrow-4.0
-          PYARROW_VERSION: "4.0.0"
-          NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "2.5.0"
-          PYSPARK_VERSION: "3.0.0"
-          ARROW_PRE_0_15_IPC_FORMAT: 0
-          PY: "3.7"
         - config: latest
-          PYARROW_VERSION: "6.0.1"
-          NUMPY_VERSION: "1.21.5"
-          TF_VERSION: "2.8.0"
-          PYSPARK_VERSION: "3.0.0"
+          PYARROW_VERSION: "9.0.0"
+          NUMPY_VERSION: "1.21.6"
+          TF_VERSION: "2.10.0"
+          PYSPARK_VERSION: "3.3.0"
           ARROW_PRE_0_15_IPC_FORMAT: "0"
           PY: "3.9"
 


### PR DESCRIPTION
Does not seem to be anything special in pyarrow 4, so dropped it.