### PR TITLE
Make `make_spark_converter` supports creating converter from a saved dataframe path

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,7 @@ Release notes
 
 Release 0.12.2 (unreleased)
 ===========================
+- `PR 787 <https://github.com/uber/petastorm/pull/787>`_: Make ``make_spark_converter`` supports creating converter from a saved Spark DataFrame path.
 
 
 Release 0.12.1

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,7 +6,7 @@ Release notes
 
 Release 0.12.2 (unreleased)
 ===========================
-- `PR 787 <https://github.com/uber/petastorm/pull/787>`_: Make ``make_spark_converter`` supports creating converter from a saved Spark DataFrame path.
+- `PR 787 <https://github.com/uber/petastorm/pull/787>`_: ``make_spark_converter`` supports creating converter from a saved Spark DataFrame path.
 
 
 Release 0.12.1

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -706,8 +706,8 @@ def make_spark_converter(
                 (dataset_dir_url.startswith("dbfs:/") and not dataset_dir_url.startswith("dbfs://"))
             ):
                 raise ValueError(
-                    "On databricks runtime, if `df` argument is a string, it must be a path "
-                    "starting with 'file:/dbfs/' or 'file:///dbfs/' or 'dbfs:/'"
+                    "On databricks runtime, if `df` argument is a string, it must be a dbfs "
+                    "fuse path like 'file:/dbfs/xxx' or a dbfs path like 'dbfs:/xxx'."
                 )
             if dataset_dir_url.startswith("dbfs:///"):
                 # convert it to a dbfs fuse path

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -692,14 +692,17 @@ def make_spark_converter(
             if not (
                 dataset_dir_url.startswith("file:/dbfs/") or
                 dataset_dir_url.startswith("file:///dbfs/") or
-                dataset_dir_url.startswith("dbfs:/")
+                dataset_dir_url.startswith("dbfs:///") or
+                (dataset_dir_url.startswith("dbfs:/") and not dataset_dir_url.startswith("dbfs://"))
             ):
                 raise ValueError(
                     "On databricks runtime, if `df` argument is a string, it must be a path "
                     "starting with 'file:/dbfs/' or 'file:///dbfs/' or 'dbfs:/'"
                 )
-            if dataset_dir_url.startswith("dbfs:/"):
+            if dataset_dir_url.startswith("dbfs:///"):
                 # convert it to a dbfs fuse path
+                dataset_dir_url = "file:/dbfs/" + dataset_dir_url[len("dbfs:///"):]
+            elif dataset_dir_url.startswith("dbfs:/"):
                 dataset_dir_url = "file:/dbfs/" + dataset_dir_url[len("dbfs:/"):]
     else:
         # TODO: Improve default behavior to be automatically choosing the best way.

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -684,7 +684,7 @@ def make_spark_converter(
 
     :param df: The :class:`pyspark.sql.DataFrame` object to be converted,
                or a string of path pointing to the directory that stores the dataframe data
-               as parquet or delta format, on databricks runtime, the path must be a dbfs
+               as parquet format, on databricks runtime, the path must be a dbfs
                fuse path like 'file:/dbfs/xxx' or a dbfs path like 'dbfs:/xxx'.
     :param parquet_row_group_size_bytes: An int denoting the number of bytes
         in a parquet row group when materializing the dataframe.

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -724,4 +724,4 @@ def make_spark_converter(
     parquet_file_url_list = list(spark_df._jdf.inputFiles())
     _check_dataset_file_median_size(parquet_file_url_list)
 
-    return SparkDatasetConverter(dataset_cache_dir_url, parquet_file_url_list, dataset_size)
+    return SparkDatasetConverter(dataset_dir_url, parquet_file_url_list, dataset_size)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -457,7 +457,17 @@ def _check_url(dir_url):
 def _check_parent_cache_dir_url(dir_url):
     """Check dir url whether is suitable to be used as parent cache directory."""
     _check_url(dir_url)
-    fs, dir_path = get_filesystem_and_path_or_paths(dir_url)
+    try:
+        fs, dir_path = get_filesystem_and_path_or_paths(dir_url)
+    except Exception:
+        if 'DATABRICKS_RUNTIME_VERSION' in os.environ:
+            raise ValueError(
+                "On databricks runtime, you should specify "
+                f"'{SparkDatasetConverter.PARENT_CACHE_DIR_URL_CONF}' config to a dbfs fuse path "
+                "like 'file:/dbfs/...'."
+            )
+        raise
+
     if 'DATABRICKS_RUNTIME_VERSION' in os.environ and not _is_spark_local_mode():
         if isinstance(fs, LocalFileSystem):
             # User need to use dbfs fuse URL.

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -678,8 +678,8 @@ def make_spark_converter(
 
     :param df: The :class:`pyspark.sql.DataFrame` object to be converted,
                or a string of path pointing to the directory that stores the dataframe data
-               as parquet or delta format, on databricks runtime, the path must starts
-               with 'file:/dbfs/', 'file:///dbfs/' or 'dbfs:/'.
+               as parquet or delta format, on databricks runtime, the path must be a dbfs
+               fuse path like 'file:/dbfs/xxx' or a dbfs path like 'dbfs:/xxx'.
     :param parquet_row_group_size_bytes: An int denoting the number of bytes
         in a parquet row group when materializing the dataframe.
     :param compression_codec: Specify compression codec.

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -485,7 +485,7 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
     If not, cache the df into the cache_dir in parquet format and return the
     cache file path.
     Use atexit to delete the cache before the python interpreter exits.
-    :param df: A :class:`DataFrame` object.
+    :param df: A :class:`pyspark.sql.DataFrame` object.
     :param parquet_row_group_size_bytes: An int denoting the number of bytes
         in a parquet row group.
     :param compression_codec: Specify compression codec.
@@ -666,7 +666,10 @@ def make_spark_converter(
     `SparkDatasetConverter.delete`, and when the spark application exit,
     it will try best effort to delete the materialized dataframe data.
 
-    :param df: The :class:`DataFrame` object to be converted.
+    :param df: The :class:`pyspark.sql.DataFrame` object to be converted,
+               or a string of path pointing to the directory that stores the dataframe data
+               as parquet or delta format, on databricks runtime, the path must starts
+               with 'file:/dbfs/', 'file:///dbfs/' or 'dbfs:/'.
     :param parquet_row_group_size_bytes: An int denoting the number of bytes
         in a parquet row group when materializing the dataframe.
     :param compression_codec: Specify compression codec.
@@ -683,23 +686,39 @@ def make_spark_converter(
 
     parent_cache_dir_url = _get_parent_cache_dir_url()
 
-    # TODO: Improve default behavior to be automatically choosing the best way.
-    compression_codec = compression_codec or "uncompressed"
+    if isinstance(df, str):
+        dataset_dir_url = df
+        if 'DATABRICKS_RUNTIME_VERSION' in os.environ:
+            if not (
+                dataset_dir_url.startswith("file:/dbfs/") or
+                dataset_dir_url.startswith("file:///dbfs/") or
+                dataset_dir_url.startswith("dbfs:/")
+            ):
+                raise ValueError(
+                    "On databricks runtime, if `df` argument is a string, it must be a path "
+                    "starting with 'file:/dbfs/' or 'file:///dbfs/' or 'dbfs:/'"
+                )
+            if dataset_dir_url.startswith("dbfs:/"):
+                # convert it to a dbfs fuse path
+                dataset_dir_url = "file:/dbfs/" + dataset_dir_url[len("dbfs:/"):]
+    else:
+        # TODO: Improve default behavior to be automatically choosing the best way.
+        compression_codec = compression_codec or "uncompressed"
 
-    if compression_codec.lower() not in \
-            ['uncompressed', 'bzip2', 'gzip', 'lz4', 'snappy', 'deflate']:
-        raise RuntimeError(
-            "compression_codec should be None or one of the following values: "
-            "'uncompressed', 'bzip2', 'gzip', 'lz4', 'snappy', 'deflate'")
+        if compression_codec.lower() not in \
+                ['uncompressed', 'bzip2', 'gzip', 'lz4', 'snappy', 'deflate']:
+            raise RuntimeError(
+                "compression_codec should be None or one of the following values: "
+                "'uncompressed', 'bzip2', 'gzip', 'lz4', 'snappy', 'deflate'")
 
-    dataset_cache_dir_url = _cache_df_or_retrieve_cache_data_url(
-        df, parent_cache_dir_url, parquet_row_group_size_bytes, compression_codec, dtype)
+        dataset_dir_url = _cache_df_or_retrieve_cache_data_url(
+            df, parent_cache_dir_url, parquet_row_group_size_bytes, compression_codec, dtype)
 
     # TODO: improve this by read parquet file metadata to get count
     #  Currently spark can make sure to only read the minimal column
     #  so count will usually be fast.
     spark = _get_spark_session()
-    spark_df = spark.read.parquet(dataset_cache_dir_url)
+    spark_df = spark.read.parquet(dataset_dir_url)
 
     dataset_size = spark_df.count()
     parquet_file_url_list = list(spark_df._jdf.inputFiles())

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -39,7 +39,9 @@ from petastorm.spark.spark_dataset_converter import (
     _check_dataset_file_median_size, _check_parent_cache_dir_url,
     _check_rank_and_size_consistent_with_horovod, _check_url,
     _get_horovod_rank_and_size, _get_spark_session, _make_sub_dir_url,
-    register_delete_dir_handler, _wait_file_available)
+    register_delete_dir_handler, _wait_file_available,
+    _normalize_databricks_dbfs_url,
+)
 
 from unittest import mock
 
@@ -667,3 +669,12 @@ def test_make_spark_convert_from_saved_df_path(spark_test_ctx):
     result = spark_test_ctx.spark.sparkContext.parallelize(range(1), 1) \
         .map(map_fn).collect()[0]
     assert result == 100
+
+
+def test_normalize_databricks_dbfs_url():
+    assert _normalize_databricks_dbfs_url("dbfs:/xx/yy", "") == "file:/dbfs/xx/yy"
+    assert _normalize_databricks_dbfs_url("dbfs:///xx/yy", "") == "file:/dbfs/xx/yy"
+    assert _normalize_databricks_dbfs_url("file:/dbfs/xx/yy", "") == "file:/dbfs/xx/yy"
+    assert _normalize_databricks_dbfs_url("file:///dbfs/xx/yy", "") == "file:///dbfs/xx/yy"
+    with pytest.raises(ValueError):
+        _normalize_databricks_dbfs_url("dbfs://xx/yy", "")


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

Make `make_spark_converter` supports creating converter from a saved dataframe path.
In this case, we can skip the step of materializing spark dataframe that might be slow.