### PR TITLE
Add a ThreadPool which respects the order of Parquet dataset pieces.

### DIFF
--- a/petastorm/workers_pool/__init__.py
+++ b/petastorm/workers_pool/__init__.py
@@ -24,3 +24,8 @@ class TimeoutWaitingForResultError(RuntimeError):
 
 class VentilatedItemProcessedMessage(object):
     """Object to signal that a worker has completed processing an item from the ventilation queue"""
+
+class OrderedVentilatedItemProcessedMessage(VentilatedItemProcessedMessage):
+    """Ventilated signal object which contains ordering metadata."""
+    def __init__(self, idx):
+        self.idx = idx

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -19,9 +19,9 @@ import sys
 from threading import Thread, Event
 from traceback import format_exc
 
-from six.moves import queue
+from six.moves import queue # type: ignore
 
-from petastorm.workers_pool import EmptyResultError, VentilatedItemProcessedMessage
+from petastorm.workers_pool import EmptyResultError, VentilatedItemProcessedMessage, OrderedVentilatedItemProcessedMessage
 
 # Defines how frequently will we check the stop event while waiting on a blocking queue
 IO_TIMEOUT_INTERVAL_S = 0.001
@@ -61,6 +61,33 @@ class WorkerThread(Thread):
                 (args, kargs) = self._ventilator_queue.get(block=True, timeout=IO_TIMEOUT_INTERVAL_S)
                 self._worker_impl.process(*args, **kargs)
                 self._worker_impl.publish_func(VentilatedItemProcessedMessage())
+            except queue.Empty:
+                pass
+            except WorkerTerminationRequested:
+                pass
+            except Exception as e:  # pylint: disable=broad-except
+                stderr_message = 'Worker %d terminated: unexpected exception:\n' % self._worker_impl.worker_id
+                stderr_message += format_exc()
+                sys.stderr.write(stderr_message)
+                self._results_queue.put(e)
+                break
+        if self._profiling_enabled:
+            self.prof.disable()
+
+class OrderedWorkerThread(WorkerThread):
+    def run(self):
+        if self._profiling_enabled:
+            self.prof.enable()
+        # Loop and accept messages from both channels, acting accordingly
+        while True:
+            # Check for stop event first to prevent erroneous reuse
+            if self._stop_event.is_set():
+                break
+            # If the message came from work_receiver channel
+            try:
+                (args, kargs) = self._ventilator_queue.get(block=True, timeout=IO_TIMEOUT_INTERVAL_S)
+                self._worker_impl.process(*args, **kargs)
+                self._worker_impl.publish_func(OrderedVentilatedItemProcessedMessage(kargs['piece_index']))
             except queue.Empty:
                 pass
             except WorkerTerminationRequested:
@@ -219,3 +246,86 @@ class ThreadPool(object):
     @property
     def diagnostics(self):
         return {'output_queue_size': self.results_qsize()}
+
+class OrderedThreadPool(ThreadPool):
+    def start(self, worker_class, worker_args=None, ventilator=None):
+        """Starts worker threads.
+
+        :param worker_class: A class of the worker class. The class will be instantiated in the worker process. The
+          class must implement :class:`.WorkerBase` protocol
+        :param worker_setup_args: Argument that will be passed to ``args`` property of the instantiated
+          :class:`.WorkerBase`
+        :return: ``None``
+        """
+        # Verify stop_event and raise exception if it's already set!
+        if self._stop_event.is_set():
+            raise RuntimeError('ThreadPool({}) cannot be reused! stop_event set? {}'
+                               .format(len(self._workers), self._stop_event.is_set()))
+
+        # Set up a channel to send work
+        self._ventilator_queue = queue.Queue()
+        self._results_queue = queue.Queue(self._results_queue_size)
+        self._workers = []
+        for worker_id in range(self.workers_count):
+            worker_impl = worker_class(worker_id, self._stop_aware_put, worker_args)
+            new_thread = OrderedWorkerThread(worker_impl, self._stop_event, self._ventilator_queue,
+                                      self._results_queue, self._profiling_enabled)
+            # Make the thread daemonic. Since it only reads it's ok to abort while running - no resource corruption
+            # will occur.
+            new_thread.daemon = True
+            self._workers.append(new_thread)
+
+        # Spin up all worker threads
+        for w in self._workers:
+            w.start()
+
+        if ventilator:
+            self._ventilator = ventilator
+            self._ventilator.start()
+
+        self._unordered_results_buffer = []
+        self._unordered_idx_buffer = []
+        self._next_result = 0
+
+    def get_results(self):
+        """Returns results from worker pool or re-raise worker's exception if any happen in worker thread.
+
+        :param timeout: If None, will block forever, otherwise will raise :class:`.TimeoutWaitingForResultError`
+            exception if no data received within the timeout (in seconds)
+
+        :return: arguments passed to ``publish_func(...)`` by a worker. If no more results are anticipated,
+                 :class:`.EmptyResultError`.
+        """
+
+        while True:
+            # If there is no more work to do, raise an EmptyResultError
+            if self._results_queue.empty() and self._ventilated_items == self._ventilated_items_processed:
+                # We also need to check if we are using a ventilator and if it is completed, and
+                # whether we have emptied the unordered results buffer
+                if (not self._ventilator or self._ventilator.completed()) and not len(self._unordered_idx_buffer):
+                    raise EmptyResultError()
+
+            # If the next rowgroup is in the unordered buffer, return it
+            if self._next_result in self._unordered_idx_buffer:
+                idx = self._unordered_idx_buffer.index(self._next_result)
+                self._next_result += 1
+                _ = self._unordered_idx_buffer.pop(idx)
+                return self._unordered_results_buffer.pop(idx)
+
+            try:
+                result = self._results_queue.get(timeout=_VERIFY_END_OF_VENTILATION_PERIOD)
+                if isinstance(result, VentilatedItemProcessedMessage):
+                    self._ventilated_items_processed += 1
+                    if self._ventilator:
+                        self._ventilator.processed_item()
+                    self._unordered_idx_buffer.append(result.idx)
+                    continue
+                elif isinstance(result, Exception):
+                    self.stop()
+                    self.join()
+                    raise result
+                else:
+                    self._unordered_results_buffer.append(result)
+                    continue
+            except queue.Empty:
+                continue


### PR DESCRIPTION
This PR offers a solution for #551, where the standard ThreadPool implementation can return dataset pieces out of order. 

## Contributions
- An `OrderedThreadPool` implementation, which internally keeps track of results and the pieces indexes returned by the ventilator, and only returns pieces in exact order.
- 'OrderedVentilatedItemProcessedMessage', which reports the dataset piece index to the 'OrderedThreadPool`.
- 'OrderedWorkerThread'. The only difference between this class and the original `WorkerThread` is that it returns indexed `OrderedVentilatedItemProcessedMessage` objects.
- Updates to `make_reader` and `make_batch_reader` to allow for instantation of `OrderedThreadPool` objects from string with `reader_pool_type="orderedthread"`
- Updates to the docstrings of `make_reader` and `make_batch_reader` to include the ordered option
- Dataset order testing in `test_parquet_reader.py`