### PR TITLE
Update unittest.yml to run tests only on the latest versions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,45 +22,6 @@ jobs:
   unittest:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        config: [pyspark-2.4, tf-1.15, pyarrow-3.0, pyarrow-4.0, latest]
-        include:
-        - config: pyspark-2.4
-          PYARROW_VERSION: "2.0.0"
-          NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "1.15.5"
-          PYSPARK_VERSION: "2.4.4"
-          ARROW_PRE_0_15_IPC_FORMAT: 1
-          PY: "3.7"
-        - config: tf-1.15
-          PYARROW_VERSION: "2.0.0"
-          NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "1.15.5"
-          PYSPARK_VERSION: "3.0.0"
-          ARROW_PRE_0_15_IPC_FORMAT: 0
-          PY: "3.7"
-        - config: pyarrow-3.0
-          PYARROW_VERSION: "3.0.0"
-          NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "2.5.0"
-          PYSPARK_VERSION: "3.0.0"
-          ARROW_PRE_0_15_IPC_FORMAT: 0
-          PY: "3.7"
-        - config: pyarrow-4.0
-          PYARROW_VERSION: "4.0.0"
-          NUMPY_VERSION: "1.19.1"
-          TF_VERSION: "2.5.0"
-          PYSPARK_VERSION: "3.0.0"
-          ARROW_PRE_0_15_IPC_FORMAT: 0
-          PY: "3.7"
-        - config: latest
-          PYARROW_VERSION: "6.0.1"
-          NUMPY_VERSION: "1.21.5"
-          TF_VERSION: "2.8.0"
-          PYSPARK_VERSION: "3.0.0"
-          ARROW_PRE_0_15_IPC_FORMAT: "0"
-          PY: "3.9"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -80,12 +41,12 @@ jobs:
       - name: build and run unit tests
         run: |
           sleep 30
-          export PYARROW_VERSION=${{matrix.PYARROW_VERSION}}
-          export NUMPY_VERSION=${{matrix.NUMPY_VERSION}}
-          export TF_VERSION=${{matrix.TF_VERSION}}
-          export PY=${{matrix.PY}}
-          export PYSPARK_VERSION=${{matrix.PYSPARK_VERSION}}
-          export ARROW_PRE_0_15_IPC_FORMAT=${{matrix.ARROW_PRE_0_15_IPC_FORMAT}}
+          export PYARROW_VERSION="6.0.1"
+          export NUMPY_VERSION="1.21.5"
+          export TF_VERSION="2.8.0"
+          export PY="3.9"
+          export PYSPARK_VERSION="3.0.0"
+          export ARROW_PRE_0_15_IPC_FORMAT="0"
           export RUN="docker exec -e ARROW_PRE_0_15_IPC_FORMAT=$ARROW_PRE_0_15_IPC_FORMAT petastorm_ci bash /run_in_venv.sh ${PY}"
           export PYTEST="pytest --timeout=360 -v --color=yes --cov=./ --cov-report xml:coverage.xml"
           $RUN pip install -U pip setuptools

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: codecov
         run: codecov --required
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   draft_release:
     needs: unittest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -77,16 +77,6 @@ jobs:
           petastorm/tests/test_pytorch_utils.py
           $RUN $PYTEST -Y --cov-append petastorm/tests/test_tf_autograph.py
 
-      - name: Copy coverage.xml from container
-        run: docker cp petastorm_ci:/petastorm/coverage.xml ./coverage.xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          verbose: true
-
   draft_release:
     needs: unittest
     # Only come with a tag

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -34,7 +34,6 @@ jobs:
           export CI_IMAGE=selitvin/petastorm_ci_auto:ci-image-06-29-2021
           docker pull $CI_IMAGE
           docker images
-          pip install -U codecov
           docker run -v `pwd`:/petastorm --name petastorm_ci $CI_IMAGE /bin/sh -c "sleep 3600" &
 
       # Run unit tests
@@ -78,10 +77,15 @@ jobs:
           petastorm/tests/test_pytorch_utils.py
           $RUN $PYTEST -Y --cov-append petastorm/tests/test_tf_autograph.py
 
-      - name: codecov
-        run: codecov --required
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Copy coverage.xml from container
+        run: docker cp petastorm_ci:/petastorm/coverage.xml ./coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          verbose: true
 
   draft_release:
     needs: unittest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -49,7 +49,7 @@ jobs:
           export ARROW_PRE_0_15_IPC_FORMAT="0"
           export RUN="docker exec -e ARROW_PRE_0_15_IPC_FORMAT=$ARROW_PRE_0_15_IPC_FORMAT petastorm_ci bash /run_in_venv.sh ${PY}"
           export PYTEST="pytest --timeout=360 -v --color=yes --cov=./ --cov-report xml:coverage.xml"
-          $RUN pip install -U pip setuptools
+          $RUN pip install -U pip "setuptools<70"
           $RUN pip install -e /petastorm/[test,tf,torch,docs,opencv]
           $RUN pip install --upgrade numpy==$NUMPY_VERSION
           $RUN pip install -U pyarrow==${PYARROW_VERSION} tensorflow==${TF_VERSION} pyspark==${PYSPARK_VERSION}

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ REQUIRED_PACKAGES = [
     'pyarrow>=0.17.1',
     'six>=1.5.0',
     'fsspec',
+    'setuptools<70',  # Prevent compatibility issues with newer setuptools
 ]
 
 EXTRA_REQUIRE = {


### PR DESCRIPTION
This PR does the following:
1. Update the setup tools to use version <70 to fix the CI checks
2. Remove the older pyarrow version from the checks and just keep the latest version (6.0.1)
3. Remove the codecov to unblock on the rate limit issue. We added the CODECOV_TOKEN but while it shows the check passed, it still has error uploading the code cov report and blocks the other checks to run past this