### PR TITLE
Support reproducible ordering in Petastorm

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,6 +22,17 @@ jobs:
   unittest:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [latest]
+        include:
+        - config: latest
+          PYARROW_VERSION: "6.0.1"
+          NUMPY_VERSION: "1.21.5"
+          TF_VERSION: "2.8.0"
+          PYSPARK_VERSION: "3.0.0"
+          ARROW_PRE_0_15_IPC_FORMAT: "0"
+          PY: "3.9"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -40,15 +51,15 @@ jobs:
       - name: build and run unit tests
         run: |
           sleep 30
-          export PYARROW_VERSION="6.0.1"
-          export NUMPY_VERSION="1.21.5"
-          export TF_VERSION="2.8.0"
-          export PY="3.9"
-          export PYSPARK_VERSION="3.0.0"
-          export ARROW_PRE_0_15_IPC_FORMAT="0"
+          export PYARROW_VERSION=${{matrix.PYARROW_VERSION}}
+          export NUMPY_VERSION=${{matrix.NUMPY_VERSION}}
+          export TF_VERSION=${{matrix.TF_VERSION}}
+          export PY=${{matrix.PY}}
+          export PYSPARK_VERSION=${{matrix.PYSPARK_VERSION}}
+          export ARROW_PRE_0_15_IPC_FORMAT=${{matrix.ARROW_PRE_0_15_IPC_FORMAT}}
           export RUN="docker exec -e ARROW_PRE_0_15_IPC_FORMAT=$ARROW_PRE_0_15_IPC_FORMAT petastorm_ci bash /run_in_venv.sh ${PY}"
           export PYTEST="pytest --timeout=360 -v --color=yes --cov=./ --cov-report xml:coverage.xml"
-          $RUN pip install -U pip "setuptools<70"
+          $RUN pip install -U pip "setuptools<70" 
           $RUN pip install -e /petastorm/[test,tf,torch,docs,opencv]
           $RUN pip install --upgrade numpy==$NUMPY_VERSION
           $RUN pip install -U pyarrow==${PYARROW_VERSION} tensorflow==${TF_VERSION} pyspark==${PYSPARK_VERSION}
@@ -56,6 +67,7 @@ jobs:
           $RUN mypy petastorm
           $RUN flake8 . --count --show-source --statistics
           $RUN flake8 . --count --exit-zero --max-complexity=20 --statistics
+          $RUN pylint --rcfile=.pylintrc petastorm examples -f parseable -r n
           $RUN ulimit -c unlimited -S
           $RUN bash -c "cd /petastorm/docs/autodoc && pwd && make html"
           $RUN $PYTEST -m "forked" --forked -Y \
@@ -75,6 +87,12 @@ jobs:
           petastorm/tests/test_pytorch_dataloader.py \
           petastorm/tests/test_pytorch_utils.py
           $RUN $PYTEST -Y --cov-append petastorm/tests/test_tf_autograph.py
+
+      - name: codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          required: true
 
   draft_release:
     needs: unittest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -56,7 +56,6 @@ jobs:
           $RUN mypy petastorm
           $RUN flake8 . --count --show-source --statistics
           $RUN flake8 . --count --exit-zero --max-complexity=20 --statistics
-          $RUN pylint --rcfile=.pylintrc petastorm examples -f parseable -r n
           $RUN ulimit -c unlimited -S
           $RUN bash -c "cd /petastorm/docs/autodoc && pwd && make html"
           $RUN $PYTEST -m "forked" --forked -Y \

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -293,6 +293,7 @@ class ArrowReaderWorker(WorkerBase):
         # pyarrow would fail if we request a column names that the dataset is partitioned by
         table = piece.read(columns=column_names - partition_names, partitions=self._dataset.partitions)
 
+        # print(f"DEBUG: ArrowReaderWorker: table before shuffle: {table}")
         # Handle row shuffling based on shuffle_rows setting
         if self._shuffle_rows:
             if self._random_seed is not None and self._random_seed != 0:
@@ -305,6 +306,7 @@ class ArrowReaderWorker(WorkerBase):
             # Deterministic natural order: shuffle_rows=False
             indices = np.arange(table.num_rows)
         table = table.take(indices)
+        # print(f"DEBUG: ArrowReaderWorker: table after shuffle: {table}")
 
         # Drop columns we did not explicitly request. This may happen when a table is partitioned. Besides columns
         # requested, pyarrow will also return partition values. Having these unexpected fields will break some

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -101,7 +101,10 @@ class ArrowReaderWorker(WorkerBase):
         self._transformed_schema = args[7]
         self._arrow_filters = args[8]
         self._shuffle_rows = args[9]
-        self._random_state = np.random.RandomState(seed=args[10])
+        self._random_seed = args[10]
+
+        # Initialize random number generator
+        self._rng = np.random.default_rng(self._random_seed)
 
         if self._ngram:
             raise NotImplementedError('ngrams are not supported by ArrowReaderWorker')
@@ -289,9 +292,19 @@ class ArrowReaderWorker(WorkerBase):
 
         # pyarrow would fail if we request a column names that the dataset is partitioned by
         table = piece.read(columns=column_names - partition_names, partitions=self._dataset.partitions)
+
+        # Handle row shuffling based on shuffle_rows setting
         if self._shuffle_rows:
-            indices = self._random_state.permutation(table.num_rows)
-            table = table.take(indices)
+            if self._random_seed is not None and self._random_seed != 0:
+                # Deterministic randomization: use provided seed
+                indices = self._rng.permutation(table.num_rows)
+            else:
+                # Non-deterministic randomization: use np.random directly
+                indices = np.random.permutation(table.num_rows)
+        else:
+            # Deterministic natural order: shuffle_rows=False
+            indices = np.arange(table.num_rows)
+        table = table.take(indices)
 
         # Drop columns we did not explicitly request. This may happen when a table is partitioned. Besides columns
         # requested, pyarrow will also return partition values. Having these unexpected fields will break some

--- a/petastorm/arrow_reader_worker.py
+++ b/petastorm/arrow_reader_worker.py
@@ -293,7 +293,6 @@ class ArrowReaderWorker(WorkerBase):
         # pyarrow would fail if we request a column names that the dataset is partitioned by
         table = piece.read(columns=column_names - partition_names, partitions=self._dataset.partitions)
 
-        # print(f"DEBUG: ArrowReaderWorker: table before shuffle: {table}")
         # Handle row shuffling based on shuffle_rows setting
         if self._shuffle_rows:
             if self._random_seed is not None and self._random_seed != 0:
@@ -306,7 +305,6 @@ class ArrowReaderWorker(WorkerBase):
             # Deterministic natural order: shuffle_rows=False
             indices = np.arange(table.num_rows)
         table = table.take(indices)
-        # print(f"DEBUG: ArrowReaderWorker: table after shuffle: {table}")
 
         # Drop columns we did not explicitly request. This may happen when a table is partitioned. Besides columns
         # requested, pyarrow will also return partition values. Having these unexpected fields will break some

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -159,7 +159,7 @@ def make_reader(dataset_url,
                       'To read from a non-Petastorm Parquet store use make_batch_reader')
 
     if reader_pool_type == 'thread':
-        reader_pool = ThreadPool(workers_count, results_queue_size)
+        reader_pool = ThreadPool(workers_count, results_queue_size, shuffle_rows=shuffle_rows, seed=seed)
     elif reader_pool_type == 'process':
         if pyarrow_serialize:
             warnings.warn("pyarrow_serializer was deprecated and will be removed in future versions. "
@@ -315,7 +315,7 @@ def make_batch_reader(dataset_url_or_urls,
         raise ValueError('Unknown cache_type: {}'.format(cache_type))
 
     if reader_pool_type == 'thread':
-        reader_pool = ThreadPool(workers_count, results_queue_size)
+        reader_pool = ThreadPool(workers_count, results_queue_size, shuffle_rows=shuffle_rows, seed=seed)
     elif reader_pool_type == 'process':
         serializer = ArrowTableSerializer()
         reader_pool = ProcessPool(workers_count, serializer, zmq_copy_buffers=zmq_copy_buffers)
@@ -439,7 +439,7 @@ class Reader(object):
 
         cache = cache or NullCache()
 
-        self._workers_pool = reader_pool or ThreadPool(10)
+        self._workers_pool = reader_pool or ThreadPool(10, shuffle_rows=shuffle_rows, seed=seed)
 
         # Make a schema view (a view is a Unischema containing only a subset of fields
         # Will raise an exception if invalid schema fields are in schema_fields

--- a/petastorm/reader.py
+++ b/petastorm/reader.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 # Ventilator guarantees that no more than workers + _VENTILATE_EXTRA_ROWGROUPS are processed at a moment by a
 # worker pool. This guarantees that we don't run out of memory if data consumer is slower than the Reader.
-_VENTILATE_EXTRA_ROWGROUPS = 2
+_VENTILATE_EXTRA_ROWGROUPS = 3
 
 LOCAL_DISK_CACHE = 'local-disk'
 NULL_CACHE = 'null'
@@ -475,7 +475,7 @@ class Reader(object):
         self.ventilator = self._create_ventilator(filtered_row_group_indexes, shuffle_row_groups,
                                                   normalized_shuffle_row_drop_partitions,
                                                   self.num_epochs, worker_predicate,
-                                                  self._workers_pool.workers_count + _VENTILATE_EXTRA_ROWGROUPS,
+                                                  self._workers_pool.workers_count * (1 + _VENTILATE_EXTRA_ROWGROUPS),
                                                   seed)
 
         # 5. Start workers pool

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -291,7 +291,6 @@ def test_simple_read_with_disk_cache(synthetic_dataset, reader_factory, tmpdir):
                         cache_type='local-disk', cache_location=tmpdir.strpath,
                         cache_size_limit=CACHE_SIZE, cache_row_size_estimate=ROW_SIZE_BYTES) as reader:
         ids = _readout_all_ids(reader)
-        print(f"DEBUG: ids: {ids}")
         assert 200 == len(ids)  # We read 2 epochs
         assert set(ids) == set(range(100))
 
@@ -857,10 +856,7 @@ def test_make_batch_reader_with_url_list(scalar_dataset):
     url_list = _get_local_fs_url_list(scalar_dataset.url)
     url_list = list(filter(lambda x: x.endswith('.parquet'), url_list))
 
-    print(f"DEBUG: url_list: {url_list}")
-
     with make_batch_reader(url_list, workers_count=1) as reader:
-
         row_count = 0
         for batch in reader:
             row_count += len(batch.id)

--- a/petastorm/tests/test_end_to_end.py
+++ b/petastorm/tests/test_end_to_end.py
@@ -291,6 +291,7 @@ def test_simple_read_with_disk_cache(synthetic_dataset, reader_factory, tmpdir):
                         cache_type='local-disk', cache_location=tmpdir.strpath,
                         cache_size_limit=CACHE_SIZE, cache_row_size_estimate=ROW_SIZE_BYTES) as reader:
         ids = _readout_all_ids(reader)
+        print(f"DEBUG: ids: {ids}")
         assert 200 == len(ids)  # We read 2 epochs
         assert set(ids) == set(range(100))
 
@@ -856,7 +857,10 @@ def test_make_batch_reader_with_url_list(scalar_dataset):
     url_list = _get_local_fs_url_list(scalar_dataset.url)
     url_list = list(filter(lambda x: x.endswith('.parquet'), url_list))
 
+    print(f"DEBUG: url_list: {url_list}")
+
     with make_batch_reader(url_list, workers_count=1) as reader:
+
         row_count = 0
         for batch in reader:
             row_count += len(batch.id)

--- a/petastorm/tests/test_tf_dataset.py
+++ b/petastorm/tests/test_tf_dataset.py
@@ -146,8 +146,7 @@ def test_with_dataset_repeat_after_cache(synthetic_dataset, reader_factory):
                     expected_res = list(range(len(synthetic_dataset.data)))
                     # sort dataset output since row_groups are shuffled from reader.
                     np.testing.assert_equal(sorted(actual_res), expected_res)
-                    print(f"DEBUG: actual_res: {sorted(actual_res)}")
-                    print(f"DEBUG: expected_res: {expected_res}")
+
             # Exhausted all epochs. Fetching next value should trigger OutOfRangeError
             with pytest.raises(tf.errors.OutOfRangeError):
                 sess.run(it_op)

--- a/petastorm/tests/test_tf_dataset.py
+++ b/petastorm/tests/test_tf_dataset.py
@@ -146,7 +146,8 @@ def test_with_dataset_repeat_after_cache(synthetic_dataset, reader_factory):
                     expected_res = list(range(len(synthetic_dataset.data)))
                     # sort dataset output since row_groups are shuffled from reader.
                     np.testing.assert_equal(sorted(actual_res), expected_res)
-
+                    print(f"DEBUG: actual_res: {sorted(actual_res)}")
+                    print(f"DEBUG: expected_res: {expected_res}")
             # Exhausted all epochs. Fetching next value should trigger OutOfRangeError
             with pytest.raises(tf.errors.OutOfRangeError):
                 sess.run(it_op)

--- a/petastorm/workers_pool/tests/test_workers_pool.py
+++ b/petastorm/workers_pool/tests/test_workers_pool.py
@@ -141,15 +141,17 @@ class TestWorkersPool(unittest.TestCase):
         SLEEP_DELTA = 0.01
         TIMEOUT = 20
         QUEUE_SIZE = 2
+        WORKERS_COUNT = 10
 
-        pool = ThreadPool(10, results_queue_size=QUEUE_SIZE)
+        pool = ThreadPool(WORKERS_COUNT, results_queue_size=QUEUE_SIZE)
         pool.start(WorkerIdGeneratingWorker)
 
-        for _ in range(100):
+        for _ in range(1000):
             pool.ventilate()
 
+        expected_queue_size = WORKERS_COUNT * max(5, QUEUE_SIZE // WORKERS_COUNT)
         cumulative_wait = 0
-        while pool.results_qsize() != QUEUE_SIZE:
+        while pool.results_qsize() != expected_queue_size:
             time.sleep(SLEEP_DELTA)
             cumulative_wait += SLEEP_DELTA
             # Make sure we wait no longer than the timeout. Otherwise, something is very wrong

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -123,7 +123,10 @@ class ThreadPool(object):
         # Set up a channel for each worker to send work
         self._ventilator_queues = [queue.Queue() for _ in range(self.workers_count)]
         # Set up a channel for each worker to send results
-        self._results_queues = [queue.Queue(5) for _ in range(self.workers_count)]
+        self._results_queues = [
+            queue.Queue(max(5, self._results_queue_size // self.workers_count))
+            for _ in range(self.workers_count)
+        ]
         self._workers = []
         for worker_id in range(self.workers_count):
             # Create a closure that captures the worker_id for this specific worker

--- a/petastorm/workers_pool/thread_pool.py
+++ b/petastorm/workers_pool/thread_pool.py
@@ -151,9 +151,7 @@ class ThreadPool(object):
         """
         current_worker_id = self._ventilated_items % self.workers_count
         self._ventilated_items += 1
-        print(f"DEBUG: Inside ventilate, ventilated_items: {self._ventilated_items}")
         self._ventilated_items_by_worker[current_worker_id] += 1
-        print(f"DEBUG: Inside ventilate, ventilated_items_by_worker: {self._ventilated_items_by_worker}")
         self._ventilator_queues[current_worker_id].put((args, kargs))
 
     def current_worker_done(self, worker_id):
@@ -177,23 +175,11 @@ class ThreadPool(object):
         :return: arguments passed to ``publish_func(...)`` by a worker. If no more results are anticipated,
                  :class:`.EmptyResultError`.
         """
-        print(f"DEBUG: ventilated_items: {self._ventilated_items}")
-        print(f"DEBUG: ventilated_items_by_worker: {self._ventilated_items_by_worker}")
-        print(f"DEBUG: ventilated_items_processed_by_worker: {self._ventilated_items_processed_by_worker}")
-        print(f"DEBUG: get_results_worker_id: {self._get_results_worker_id}")
-        print(f"DEBUG: workers_count: {self.workers_count}")
-        for i, q in enumerate(self._results_queues):
-            print(f"DEBUG: results_queue[{i}] size: {q.qsize()}")
-        print(f"DEBUG: stop_event: {self._stop_event.is_set()}")
-        print(f"DEBUG: ventilator: {self._ventilator}")
-
         while True:
             # If there is no more work to do, raise an EmptyResultError
             if self.all_workers_done():
-                print("DEBUG: all_workers_done")
                 # We also need to check if we are using a ventilator and if it is completed
                 if not self._ventilator or self._ventilator.completed():
-                    print("DEBUG: all_workers_done and ventilator completed")
                     raise EmptyResultError()
 
             # If the current worker is done, we need to get the result from the next worker
@@ -207,8 +193,6 @@ class ThreadPool(object):
                 )
                 if isinstance(result, VentilatedItemProcessedMessage):
                     self._ventilated_items_processed_by_worker[self._get_results_worker_id] += 1
-                    print(f"DEBUG: Inside get_results, "
-                          f"ventilated_items_processed_by_worker: {self._ventilated_items_processed_by_worker}")
                     if self._ventilator:
                         self._ventilator.processed_item()
                     # Move to the next worker
@@ -219,7 +203,6 @@ class ThreadPool(object):
                     self.join()
                     raise result
                 else:
-                    print(f"DEBUG: get_results: result: {result}")
                     return result
             except queue.Empty:
                 continue

--- a/petastorm/workers_pool/ventilator.py
+++ b/petastorm/workers_pool/ventilator.py
@@ -123,9 +123,6 @@ class ConcurrentVentilator(Ventilator):
 
     def completed(self):
         assert self._iterations_remaining is None or self._iterations_remaining >= 0
-        print(f"DEBUG: completed: {self._stop_requested}")
-        print(f"DEBUG: iterations_remaining: {self._iterations_remaining}")
-        print(f"DEBUG: items_to_ventilate: {self._items_to_ventilate}")
         return self._stop_requested or self._iterations_remaining == 0 or not self._items_to_ventilate
 
     def reset(self):

--- a/petastorm/workers_pool/ventilator.py
+++ b/petastorm/workers_pool/ventilator.py
@@ -123,6 +123,9 @@ class ConcurrentVentilator(Ventilator):
 
     def completed(self):
         assert self._iterations_remaining is None or self._iterations_remaining >= 0
+        print(f"DEBUG: completed: {self._stop_requested}")
+        print(f"DEBUG: iterations_remaining: {self._iterations_remaining}")
+        print(f"DEBUG: items_to_ventilate: {self._items_to_ventilate}")
         return self._stop_requested or self._iterations_remaining == 0 or not self._items_to_ventilate
 
     def reset(self):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIRED_PACKAGES = [
     'psutil>=4.0.0',
     'pyspark>=2.1.0',
     'pyzmq>=14.0.0',
-    'pyarrow>=0.17.1',
+    'pyarrow>=6.0.1',
     'six>=1.5.0',
     'fsspec',
     'setuptools<70',  # Prevent compatibility issues with newer setuptools


### PR DESCRIPTION
This PR addresses the issue where the reader doesn't give reproducible data order for multiple workers when shuffling is disabled or seed is set. The following changes are made to address the issue:

1. Ventilator Queue Modifications: Each worker now has a separate ventilator queue, ensuring deterministic data ordering through a round-robin strategy and eliminating race conditions.

2. np.default_rng(): The switch from np.random.RandomState() to np.default_rng() provides reproducible shuffling, ensuring consistent outcomes when a seed is provided.

3. Result Queue Improvements: Individual result queues for each worker have been implemented. Results are collected in a round-robin manner.

The following behavior is expected as a result of this change:
1. Shuffling = False, Deterministically natural order 
2. Shuffling = True, Seed = Provided, Deterministically randomized order
3. Shuffling = True, Seed = Not Provided (or 0), Non-deterministically randomized order

Testing and Validation: Added unit tests to cover the 3 scenario stated. Also, performed experiments that confirmed that data order remains consistent when shuffling is disabled and is reproducible with a seed, improving the reliability of dataloader.

